### PR TITLE
Update node and docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM node:20
+FROM node:22-alpine
 WORKDIR /app
-COPY . .
+RUN adduser -D appuser
+RUN chown appuser /app
+COPY --chown=appuser . .
+USER appuser
 RUN npm install
 RUN wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
 EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -f http://localhost:3000/health-check || exit 1
 CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   api:
     build: .


### PR DESCRIPTION
Updated to node 22.
Alpine base OS.
Builds 192MB image vs. 1.13GB.
Runs as a non-root user.
Adds a docker health check. 
192MB image vs. 1.13GB.
Removed version from docker-compose.yml.