### PR TITLE
Fix duplicates in classes materialized view

### DIFF
--- a/sql/classes.sql
+++ b/sql/classes.sql
@@ -88,6 +88,9 @@ classes as (
 	from section
 	    join courseoffering
             on section.localcoursecode = courseoffering.localcoursecode
+            AND section.schoolid = courseoffering.schoolid
+            AND section.schoolyear = courseoffering.schoolyear  
+            AND section.sessionname = courseoffering.sessionname
 	    left join periods
             on section.sectionidentifier = periods.sectionidentifier
 )


### PR DESCRIPTION
PROBLEM:
PostgreSQL classes view produces 1,064 rows instead of 532 in GrandBend, with each class appearing twice using the same sourcedId

ROOT CAUSE:
Incomplete JOIN between section and courseoffering tables:

- Only joined on localcoursecode
- Missing schoolid, schoolyear, sessionname fields
- Creates cartesian product when multiple course offerings exist

SOLUTION:
Add complete JOIN conditions matching MSSQL implementation:

- JOIN on localcoursecode, schoolid, schoolyear, sessionname
- Ensures proper 1:1 mapping between sections and classes
- Maintains sourcedId uniqueness per OneRoster specification

VALIDATION:
- Before: 1,064 rows, 532 unique sourcedIds (duplicates)
- After: Expected 532 rows, 532 unique sourcedIds (no duplicates)

🤖 Generated with Claude Code

Note 1: Found while starting to look at MSSQL artifacts.
Note 2: If this is a valid bug, then I believe the tests/row-counts.sql script also needs to be updated to remove DISTINCT clauses?