### PR TITLE
Fix PostgreSQL orgs.sql to use natural keys for parent organization references

### DIFF
--- a/sql/orgs.sql
+++ b/sql/orgs.sql
@@ -6,23 +6,19 @@ with schools as (
     select
         school.*,
     	schoolOrg.*,
-        leaOrg.id as leaId
+        school.localEducationAgencyId as leaId
     from edfi.school
         join edfi.educationOrganization schoolOrg
             on schoolOrg.educationOrganizationId = school.schoolId
-        left join edfi.educationOrganization leaOrg
-            on leaOrg.educationOrganizationId = school.localEducationAgencyId
 ),
 leas as (
     select
         localEducationAgency.*,
         leaOrg.*,
-        seaOrg.id as seaId
+        localEducationAgency.stateEducationAgencyId as seaId
     from edfi.localEducationAgency
         join edfi.educationOrganization leaOrg
             on leaOrg.educationOrganizationId = localEducationAgency.localEducationAgencyId
-        left join edfi.educationOrganization seaOrg
-            on seaOrg.educationOrganizationId = localEducationAgency.stateEducationAgencyId
 ),
 seas as (
     select


### PR DESCRIPTION
 ## Summary
  - Fix PostgreSQL orgs.sql to use natural keys instead of surrogate keys for parent organization references
  - Ensures consistent MD5 hash generation between PostgreSQL and MSSQL databases

  ## Changes
  - Replace `leaOrg.id as leaId` with `school.localEducationAgencyId as leaId` 
  - Replace `seaOrg.id as seaId` with `localEducationAgency.stateEducationAgencyId as seaId`
  - Remove unnecessary JOINs to educationOrganization table for parent references