### PR TITLE
migrate fix for standardizing error response to refactored code

### DIFF
--- a/src/controllers/unified/oneRosterController.js
+++ b/src/controllers/unified/oneRosterController.js
@@ -80,7 +80,9 @@ async function doOneRosterEndpointMany(req, res, endpoint, config, extraWhere = 
             || (endpoint!='demographics' && !scope.includes('https://purl.imsglobal.org/spec/or/v1p2/scope/roster-core.readonly') && !scope.includes('https://purl.imsglobal.org/spec/or/v1p2/scope/roster.readonly'))
         ) {
             return res.status(403).json({
-                message: `Insufficient scope: your token must have the 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster.readonly' or '${endpoint=='demographics' ? 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster-demographics.readonly' : 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster-core.readonly'}' scope to access this route.`
+                imsx_codeMajor: 'failure',
+                imsx_severity: 'error',
+                imsx_description: `Insufficient scope: your token must have the 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster.readonly' or '${endpoint=='demographics' ? 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster-demographics.readonly' : 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster-core.readonly'}' scope to access this route.`
             });
         }
     }
@@ -144,7 +146,9 @@ async function doOneRosterEndpointOne(req, res, endpoint, extraWhere = null) {
             || (endpoint!='demographics' && !scope.includes('https://purl.imsglobal.org/spec/or/v1p2/scope/roster-core.readonly') && !scope.includes('https://purl.imsglobal.org/spec/or/v1p2/scope/roster.readonly'))
         ) {
             return res.status(403).json({
-                message: `Insufficient scope: your token must have the 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster.readonly' or '${endpoint=='demographics' ? 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster-demographics.readonly' : 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster-core.readonly'}' scope to access this route.`
+                imsx_codeMajor: 'failure',
+                imsx_severity: 'error',
+                imsx_description: `Insufficient scope: your token must have the 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster.readonly' or '${endpoint=='demographics' ? 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster-demographics.readonly' : 'https://purl.imsglobal.org/spec/or/v1p2/scope/roster-core.readonly'}' scope to access this route.`
             });
         }
     }

--- a/src/routes/oneRoster.js
+++ b/src/routes/oneRoster.js
@@ -31,7 +31,11 @@ router.get('/rostering/v1p2/students', oneRosterController.students);
 router.get('/rostering/v1p2/teachers', oneRosterController.teachers);
 
 router.get('/{*any}', function(req, res){
-  res.status(404).json({ error: 'Not found' });
+  res.status(404).json({
+    imsx_codeMajor: 'failure',
+    imsx_severity: 'error',
+    imsx_description: 'The specified resource was not found'
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
Standardize error responses to OneRoster imsx_statusinfo format

  - Replace message/error/details with imsx_codeMajor/imsx_severity/imsx_description
  - Update 401, 403, 404 responses across app.js, controllers, and routes
  - Add 422 and 429 error handling with OneRoster format
  - Ensures OneRoster 1.2 specification compliance