### PR TITLE
[ONEROSTER-35] Course refresh is running into PK violation error

### DIFF
--- a/standard/4.0.0/artifacts/mssql/core/courses.sql
+++ b/standard/4.0.0/artifacts/mssql/core/courses.sql
@@ -117,7 +117,7 @@ BEGIN
         WITH course AS (
             SELECT * FROM edfi.Course
         ),
-        course_leas AS (
+        course_offerings AS (
           SELECT DISTINCT CourseCode, SchoolYear
           FROM edfi.CourseOffering
         )
@@ -131,10 +131,10 @@ BEGIN
             'active' AS status,
             crs.LastModifiedDate AS dateLastModified,
             CASE
-                WHEN course_leas.SchoolYear IS NOT NULL THEN
+                WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_leas.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_leas.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL
@@ -156,7 +156,7 @@ BEGIN
              FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS metadata,
             crs.EducationOrganizationId AS educationOrganizationId
         FROM course crs
-        LEFT JOIN course_leas ON crs.CourseCode = course_leas.CourseCode
+        LEFT JOIN course_offerings ON crs.CourseCode = course_offerings.CourseCode
         ;
 
         SET @RowCount = @@ROWCOUNT;

--- a/standard/4.0.0/artifacts/mssql/core/courses.sql
+++ b/standard/4.0.0/artifacts/mssql/core/courses.sql
@@ -117,11 +117,9 @@ BEGIN
         WITH course AS (
             SELECT * FROM edfi.Course
         ),
-        -- want courses defined by district, so grab this from offerings and reduce down
         course_leas AS (
-            SELECT DISTINCT CourseCode, SchoolYear, s.LocalEducationAgencyId
-            FROM edfi.CourseOffering co
-            JOIN edfi.School s ON co.SchoolId = s.SchoolId
+          SELECT DISTINCT CourseCode, SchoolYear
+          FROM edfi.CourseOffering
         )
         INSERT INTO #staging_courses
         SELECT

--- a/standard/4.0.0/artifacts/pgsql/core/courses.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/courses.sql
@@ -10,12 +10,9 @@ create materialized view if not exists oneroster12.courses as
 with course as (
     select * from edfi.course
 ),
--- want courses defined by district, so grab this from offerings and reduce down
 course_leas as (
-    select distinct coursecode, schoolyear, s.localEducationAgencyid
-    from edfi.courseoffering co
-        join edfi.school s
-            on co.schoolid = s.schoolid
+    select distinct coursecode, schoolyear
+    from edfi.courseoffering
 )
 -- property documentation at
 -- https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#Main6p8p2

--- a/standard/4.0.0/artifacts/pgsql/core/courses.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/courses.sql
@@ -10,7 +10,7 @@ create materialized view if not exists oneroster12.courses as
 with course as (
     select * from edfi.course
 ),
-course_leas as (
+course_offerings as (
     select distinct coursecode, schoolyear
     from edfi.courseoffering
 )
@@ -25,10 +25,10 @@ select
     crs.lastmodifieddate as "dateLastModified",
     coursetitle as "title",
     CASE
-        WHEN course_leas.schoolyear IS NOT NULL THEN
+        WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(course_leas.schoolyear::text)),
-                'sourcedId', md5(course_leas.schoolyear::text),
+                'href', concat('/academicSessions/', md5(course_offerings.schoolyear::text)),
+                'sourcedId', md5(course_offerings.schoolyear::text),
                 'type', 'academicSession'
             )
         ELSE NULL
@@ -54,8 +54,8 @@ select
     ) AS metadata,
     crs.educationOrganizationId as "educationOrganizationId"
 from course crs
-    left join course_leas
-        on crs.coursecode = course_leas.coursecode;
+    left join course_offerings
+        on crs.coursecode = course_offerings.coursecode;
 
 -- Add an index so the materialized view can be refreshed _concurrently_:
 create index if not exists courses_sourcedid ON oneroster12.courses ("sourcedId");

--- a/standard/5.2.0/artifacts/mssql/core/courses.sql
+++ b/standard/5.2.0/artifacts/mssql/core/courses.sql
@@ -117,7 +117,7 @@ BEGIN
         WITH course AS (
             SELECT * FROM edfi.Course
         ),
-        course_leas AS (
+        course_offerings AS (
           SELECT DISTINCT CourseCode, SchoolYear
           FROM edfi.CourseOffering
         )
@@ -131,10 +131,10 @@ BEGIN
             'active' AS status,
             crs.LastModifiedDate AS dateLastModified,
             CASE
-                WHEN course_leas.SchoolYear IS NOT NULL THEN
+                WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_leas.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_leas.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL
@@ -156,7 +156,7 @@ BEGIN
              FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS metadata,
             crs.EducationOrganizationId AS educationOrganizationId
         FROM course crs
-        LEFT JOIN course_leas ON crs.CourseCode = course_leas.CourseCode
+        LEFT JOIN course_offerings ON crs.CourseCode = course_offerings.CourseCode
         ;
 
         SET @RowCount = @@ROWCOUNT;

--- a/standard/5.2.0/artifacts/mssql/core/courses.sql
+++ b/standard/5.2.0/artifacts/mssql/core/courses.sql
@@ -117,11 +117,9 @@ BEGIN
         WITH course AS (
             SELECT * FROM edfi.Course
         ),
-        -- want courses defined by district, so grab this from offerings and reduce down
         course_leas AS (
-            SELECT DISTINCT CourseCode, SchoolYear, s.LocalEducationAgencyId
-            FROM edfi.CourseOffering co
-            JOIN edfi.School s ON co.SchoolId = s.SchoolId
+          SELECT DISTINCT CourseCode, SchoolYear
+          FROM edfi.CourseOffering
         )
         INSERT INTO #staging_courses
         SELECT

--- a/standard/5.2.0/artifacts/pgsql/core/courses.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/courses.sql
@@ -10,12 +10,9 @@ create materialized view if not exists oneroster12.courses as
 with course as (
     select * from edfi.course
 ),
--- want courses defined by district, so grab this from offerings and reduce down
 course_leas as (
-    select distinct coursecode, schoolyear, s.localEducationAgencyid
-    from edfi.courseoffering co
-        join edfi.school s
-            on co.schoolid = s.schoolid
+    select distinct coursecode, schoolyear
+    from edfi.courseoffering
 )
 -- property documentation at
 -- https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#Main6p8p2

--- a/standard/5.2.0/artifacts/pgsql/core/courses.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/courses.sql
@@ -10,7 +10,7 @@ create materialized view if not exists oneroster12.courses as
 with course as (
     select * from edfi.course
 ),
-course_leas as (
+course_offerings as (
     select distinct coursecode, schoolyear
     from edfi.courseoffering
 )
@@ -25,10 +25,10 @@ select
     crs.lastmodifieddate as "dateLastModified",
     coursetitle as "title",
     CASE
-        WHEN course_leas.schoolyear IS NOT NULL THEN
+        WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(course_leas.schoolyear::text)),
-                'sourcedId', md5(course_leas.schoolyear::text),
+                'href', concat('/academicSessions/', md5(course_offerings.schoolyear::text)),
+                'sourcedId', md5(course_offerings.schoolyear::text),
                 'type', 'academicSession'
             )
         ELSE NULL
@@ -54,8 +54,8 @@ select
     ) AS metadata,
     crs.educationOrganizationId as "educationOrganizationId"
 from course crs
-    left join course_leas
-        on crs.coursecode = course_leas.coursecode;
+    left join course_offerings
+        on crs.coursecode = course_offerings.coursecode;
 
 -- Add an index so the materialized view can be refreshed _concurrently_:
 create index if not exists courses_sourcedid ON oneroster12.courses ("sourcedId");


### PR DESCRIPTION
 Fix: PK violation for SEA-defined courses in OneRoster courses endpoint

 **Background**

  In Ed-Fi, a Course can be defined at the SEA, LEA, or school level. The OneRoster /courses endpoint should return
  each unique course once, with sourcedId derived from (educationOrganizationId, courseCode).

  **Problem**

  When a course is defined at the SEA level, the same CourseCode can be offered by schools across multiple LEAs. The
   previous query joined courses against a course_leas CTE that included LocalEducationAgencyId in its DISTINCT
  clause. This caused one output row per LEA for each SEA-defined course — all with the same sourcedId — resulting
  in a primary key violation during the staging table insert.

  **Fix**

  Removed LocalEducationAgencyId from the CTE (renamed course_leas → course_offerings) so it returns DISTINCT
  CourseCode, SchoolYear only. Since the database holds data for a single school year, this guarantees at most one
  row per CourseCode, eliminating the fan-out regardless of how many schools or LEAs offer the course.