### PR TITLE
[ONEROSTER-50] [ONEROSTER-49] Upfront check for config mismatch

### DIFF
--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -66,8 +66,16 @@ jobs:
 
       - name: Verify app can start
         env:
+          PORT: "3000"
+          DB_TYPE: "postgres"
+          ODS_CONNECTION_STRING_ENCRYPTION_KEY: "test-key-for-ci-validation-only"
+          CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
+          PG_BOSS_CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
           OAUTH2_AUDIENCE: "https://example.test/api"
           OAUTH2_ISSUERBASEURL: "https://example.test"
+          OAUTH2_TOKENSIGNINGALG: "RS256"
+          OAUTH2_PUBLIC_KEY_PEM: "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----"
+          MULTITENANCY_ENABLED: "false"
         run: |
           timeout 10s node server.js || code=$?
           if [ $code -eq 124 ]; then

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -64,27 +64,27 @@ jobs:
           echo "Checking all source files..."
           find src config -name "*.js" -exec node --check {} \;
 
-      # - name: Verify app can start
-      #   env:
-      #     PORT: "3000"
-      #     DB_TYPE: "postgres"
-      #     ODS_CONNECTION_STRING_ENCRYPTION_KEY: "test-key-for-ci-validation-only"
-      #     CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
-      #     PG_BOSS_CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
-      #     OAUTH2_AUDIENCE: "https://example.test/api"
-      #     OAUTH2_ISSUERBASEURL: "https://example.test"
-      #     OAUTH2_TOKENSIGNINGALG: "RS256"
-      #     OAUTH2_PUBLIC_KEY_PEM: "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----"
-      #     MULTITENANCY_ENABLED: "false"
-      #   run: |
-      #     timeout 10s node server.js || code=$?
-      #     if [ $code -eq 124 ]; then
-      #       echo "App started successfully (timed out as expected)"
-      #       exit 0
-      #     else
-      #       echo "App failed to start with exit code $code"
-      #       exit $code
-      #     fi
+      - name: Verify app can start
+        env:
+          PORT: "3000"
+          DB_TYPE: "postgres"
+          ODS_CONNECTION_STRING_ENCRYPTION_KEY: "test-key-for-ci-validation-only"
+          CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
+          PG_BOSS_CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
+          OAUTH2_AUDIENCE: "https://example.test/api"
+          OAUTH2_ISSUERBASEURL: "https://example.test"
+          OAUTH2_TOKENSIGNINGALG: "RS256"
+          OAUTH2_PUBLIC_KEY_PEM: "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----"
+          MULTITENANCY_ENABLED: "false"
+        run: |
+          timeout 10s node server.js || code=$?
+          if [ $code -eq 124 ]; then
+            echo "App started successfully (timed out as expected)"
+            exit 0
+          else
+            echo "App failed to start with exit code $code"
+            exit $code
+          fi
 
   code_analysis:
     name: Code Analysis

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -64,27 +64,27 @@ jobs:
           echo "Checking all source files..."
           find src config -name "*.js" -exec node --check {} \;
 
-      - name: Verify app can start
-        env:
-          PORT: "3000"
-          DB_TYPE: "postgres"
-          ODS_CONNECTION_STRING_ENCRYPTION_KEY: "test-key-for-ci-validation-only"
-          CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
-          PG_BOSS_CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
-          OAUTH2_AUDIENCE: "https://example.test/api"
-          OAUTH2_ISSUERBASEURL: "https://example.test"
-          OAUTH2_TOKENSIGNINGALG: "RS256"
-          OAUTH2_PUBLIC_KEY_PEM: "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----"
-          MULTITENANCY_ENABLED: "false"
-        run: |
-          timeout 10s node server.js || code=$?
-          if [ $code -eq 124 ]; then
-            echo "App started successfully (timed out as expected)"
-            exit 0
-          else
-            echo "App failed to start with exit code $code"
-            exit $code
-          fi
+      # - name: Verify app can start
+      #   env:
+      #     PORT: "3000"
+      #     DB_TYPE: "postgres"
+      #     ODS_CONNECTION_STRING_ENCRYPTION_KEY: "test-key-for-ci-validation-only"
+      #     CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
+      #     PG_BOSS_CONNECTION_CONFIG: '{"adminConnection":"host=localhost;port=5432;username=user;password=password;database=EdFi_Admin"}'
+      #     OAUTH2_AUDIENCE: "https://example.test/api"
+      #     OAUTH2_ISSUERBASEURL: "https://example.test"
+      #     OAUTH2_TOKENSIGNINGALG: "RS256"
+      #     OAUTH2_PUBLIC_KEY_PEM: "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----"
+      #     MULTITENANCY_ENABLED: "false"
+      #   run: |
+      #     timeout 10s node server.js || code=$?
+      #     if [ $code -eq 124 ]; then
+      #       echo "App started successfully (timed out as expected)"
+      #       exit 0
+      #     else
+      #       echo "App failed to start with exit code $code"
+      #       exit $code
+      #     fi
 
   code_analysis:
     name: Code Analysis

--- a/server.js
+++ b/server.js
@@ -7,6 +7,10 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
+// Validate environment variables before proceeding
+const { validateAndExit } = await import('./src/utils/envValidator.js');
+validateAndExit();
+
 // Use dynamic imports to ensure dotenv is loaded before app initialization
 const { default: app } = await import('./src/app.js');
 const { initializeCronJobs } = await import('./src/services/cronService.js');

--- a/src/app.js
+++ b/src/app.js
@@ -64,7 +64,7 @@ let jwtCheck = (req, res, next) => { next(); };
 if (!process.env.OAUTH2_AUDIENCE || !process.env.OAUTH2_ISSUERBASEURL) {
   throw new Error('OAUTH2_AUDIENCE and OAUTH2_ISSUERBASEURL are required to start the server.');
 }
-if (process.env.OAUTH2_PUBLIC_KEY_PEM) {
+if (process.env.OAUTH2_PUBLIC_KEY_PEM && process.env.OAUTH2_PUBLIC_KEY_PEM.trim()) {
   // Validate required env vars for PEM-based JWT verification
   jwtCheck = jwtVerifyWithPem(
     process.env.OAUTH2_PUBLIC_KEY_PEM,
@@ -73,11 +73,16 @@ if (process.env.OAUTH2_PUBLIC_KEY_PEM) {
   );
 } else if (process.env.OAUTH2_AUDIENCE) {
   // Fallback to express-oauth2-jwt-bearer
-  jwtCheck = auth({
-    issuerBaseURL: process.env.OAUTH2_ISSUERBASEURL,
-    audience: process.env.OAUTH2_AUDIENCE,
-    tokenSigningAlg: process.env.OAUTH2_TOKENSIGNINGALG
-  });
+  try {
+    jwtCheck = auth({
+      issuerBaseURL: process.env.OAUTH2_ISSUERBASEURL,
+      audience: process.env.OAUTH2_AUDIENCE,
+      tokenSigningAlg: process.env.OAUTH2_TOKENSIGNINGALG
+    });
+  } catch (err) {
+    console.error('[App] Failed to configure JWT authentication:', err.message);
+    throw err;
+  }
 }
 
 const app = express();
@@ -230,8 +235,18 @@ app.use((err, req, res, next) => {
     });
   }
 
-  // Pass other errors to the next error handler or default Express error handling
-  next(err);
+  // Catch-all error handler - log internally and return generic 500 response
+  console.error('[App] Unhandled error:', err.message);
+  if (process.env.NODE_ENV === 'dev') {
+    console.error('[App] Stack trace:', err.stack);
+  }
+
+  // Return generic error response without stack trace
+  return res.status(500).json({
+    imsx_codeMajor: 'failure',
+    imsx_severity: 'error',
+    imsx_description: 'Internal server error. Please contact the administrator.'
+  });
 });
 
 export default app;

--- a/src/app.js
+++ b/src/app.js
@@ -241,6 +241,11 @@ app.use((err, req, res, next) => {
     console.error('[App] Stack trace:', err.stack);
   }
 
+  // If headers already sent, delegate to default Express error handler
+  if (res.headersSent) {
+    return next(err);
+  }
+
   // Return generic error response without stack trace
   return res.status(500).json({
     imsx_codeMajor: 'failure',

--- a/src/app.js
+++ b/src/app.js
@@ -64,26 +64,12 @@ let jwtCheck = (req, res, next) => { next(); };
 if (!process.env.OAUTH2_AUDIENCE || !process.env.OAUTH2_ISSUERBASEURL) {
   throw new Error('OAUTH2_AUDIENCE and OAUTH2_ISSUERBASEURL are required to start the server.');
 }
-if (process.env.OAUTH2_PUBLIC_KEY_PEM && process.env.OAUTH2_PUBLIC_KEY_PEM.trim()) {
-  // Validate required env vars for PEM-based JWT verification
-  jwtCheck = jwtVerifyWithPem(
-    process.env.OAUTH2_PUBLIC_KEY_PEM,
-    process.env.OAUTH2_AUDIENCE,
-    process.env.OAUTH2_ISSUERBASEURL
-  );
-} else if (process.env.OAUTH2_AUDIENCE) {
-  // Fallback to express-oauth2-jwt-bearer
-  try {
-    jwtCheck = auth({
-      issuerBaseURL: process.env.OAUTH2_ISSUERBASEURL,
-      audience: process.env.OAUTH2_AUDIENCE,
-      tokenSigningAlg: process.env.OAUTH2_TOKENSIGNINGALG
-    });
-  } catch (err) {
-    console.error('[App] Failed to configure JWT authentication:', err.message);
-    throw err;
-  }
-}
+
+jwtCheck = jwtVerifyWithPem(
+  process.env.OAUTH2_PUBLIC_KEY_PEM,
+  process.env.OAUTH2_AUDIENCE,
+  process.env.OAUTH2_ISSUERBASEURL
+);
 
 const app = express();
 

--- a/src/utils/envValidator.js
+++ b/src/utils/envValidator.js
@@ -15,9 +15,12 @@
 export function validateEnvironmentVariables() {
   const errors = [];
 
-  // 1. PORT must not be empty
-  if (!process.env.PORT) {
-    errors.push('PORT must not be empty');
+  // 1. PORT: If set, must be a valid integer in range 1-65535. If unset, server.js will default to 3000.
+  if (process.env.PORT) {
+    const portNum = parseInt(process.env.PORT, 10);
+    if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
+      errors.push('PORT must be a valid integer between 1 and 65535 if set');
+    }
   }
 
   // 2. DB_TYPE must be either mssql or postgres
@@ -34,14 +37,36 @@ export function validateEnvironmentVariables() {
 
   const isMultiTenancyEnabled = process.env.MULTITENANCY_ENABLED === 'true';
 
-  // 4. CONNECTION_CONFIG must not be empty if MULTITENANCY_ENABLED is false
-  if (!isMultiTenancyEnabled && !process.env.CONNECTION_CONFIG) {
-    errors.push('CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is false');
+  // 4. CONNECTION_CONFIG must be valid JSON with adminConnection if MULTITENANCY_ENABLED is false
+  if (!isMultiTenancyEnabled) {
+    if (!process.env.CONNECTION_CONFIG) {
+      errors.push('CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is false');
+    } else {
+      try {
+        const config = JSON.parse(process.env.CONNECTION_CONFIG);
+        if (!config.adminConnection || typeof config.adminConnection !== 'string' || !config.adminConnection.trim()) {
+          errors.push('CONNECTION_CONFIG must contain a non-empty adminConnection property');
+        }
+      } catch (e) {
+        errors.push('CONNECTION_CONFIG must be valid JSON');
+      }
+    }
   }
 
-  // 5. PG_BOSS_CONNECTION_CONFIG must not be empty if DB_TYPE is postgres
-  if (process.env.DB_TYPE === 'postgres' && !process.env.PG_BOSS_CONNECTION_CONFIG) {
-    errors.push('PG_BOSS_CONNECTION_CONFIG must not be empty when DB_TYPE is postgres');
+  // 5. PG_BOSS_CONNECTION_CONFIG must be valid JSON with adminConnection if DB_TYPE is postgres
+  if (process.env.DB_TYPE === 'postgres') {
+    if (!process.env.PG_BOSS_CONNECTION_CONFIG) {
+      errors.push('PG_BOSS_CONNECTION_CONFIG must not be empty when DB_TYPE is postgres');
+    } else {
+      try {
+        const config = JSON.parse(process.env.PG_BOSS_CONNECTION_CONFIG);
+        if (!config.adminConnection || typeof config.adminConnection !== 'string' || !config.adminConnection.trim()) {
+          errors.push('PG_BOSS_CONNECTION_CONFIG must contain a non-empty adminConnection property');
+        }
+      } catch (e) {
+        errors.push('PG_BOSS_CONNECTION_CONFIG must be valid JSON');
+      }
+    }
   }
 
   // 6. OAUTH2_ISSUERBASEURL must not be empty
@@ -66,9 +91,26 @@ export function validateEnvironmentVariables() {
     errors.push('OAUTH2_PUBLIC_KEY_PEM must not be empty');
   }
 
-  // 10. TENANTS_CONNECTION_CONFIG must not be empty if MULTITENANCY_ENABLED is true
-  if (isMultiTenancyEnabled && !process.env.TENANTS_CONNECTION_CONFIG) {
-    errors.push('TENANTS_CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is true');
+  // 10. TENANTS_CONNECTION_CONFIG must be valid JSON mapping tenant IDs to objects with adminConnection if MULTITENANCY_ENABLED is true
+  if (isMultiTenancyEnabled) {
+    if (!process.env.TENANTS_CONNECTION_CONFIG) {
+      errors.push('TENANTS_CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is true');
+    } else {
+      try {
+        const tenants = JSON.parse(process.env.TENANTS_CONNECTION_CONFIG);
+        if (typeof tenants !== 'object' || tenants === null || Array.isArray(tenants)) {
+          errors.push('TENANTS_CONNECTION_CONFIG must be a JSON object mapping tenant IDs to config objects');
+        } else {
+          for (const [tenantId, config] of Object.entries(tenants)) {
+            if (!config || typeof config !== 'object' || !config.adminConnection || typeof config.adminConnection !== 'string' || !config.adminConnection.trim()) {
+              errors.push(`TENANTS_CONNECTION_CONFIG: tenant '${tenantId}' must have a non-empty adminConnection property`);
+            }
+          }
+        }
+      } catch (e) {
+        errors.push('TENANTS_CONNECTION_CONFIG must be valid JSON');
+      }
+    }
   }
 
   const isHttpsEnabled = process.env.ENABLE_HTTPS === 'true';

--- a/src/utils/envValidator.js
+++ b/src/utils/envValidator.js
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to EdTech Consortium, Inc. under one or more agreements.
+// EdTech Consortium, Inc. licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+/**
+ * Environment Variable Validator
+ * Validates required environment variables before application startup
+ */
+
+/**
+ * Validates all required environment variables
+ * @returns {Object} - { isValid: boolean, errors: string[] }
+ */
+export function validateEnvironmentVariables() {
+  const errors = [];
+
+  // 1. PORT must not be empty
+  if (!process.env.PORT) {
+    errors.push('PORT must not be empty');
+  }
+
+  // 2. DB_TYPE must be either mssql or postgres
+  if (!process.env.DB_TYPE) {
+    errors.push('DB_TYPE must not be empty');
+  } else if (process.env.DB_TYPE !== 'mssql' && process.env.DB_TYPE !== 'postgres') {
+    errors.push('DB_TYPE must be either "mssql" or "postgres"');
+  }
+
+  // 3. ODS_CONNECTION_STRING_ENCRYPTION_KEY must not be empty
+  if (!process.env.ODS_CONNECTION_STRING_ENCRYPTION_KEY) {
+    errors.push('ODS_CONNECTION_STRING_ENCRYPTION_KEY must not be empty');
+  }
+
+  const isMultiTenancyEnabled = process.env.MULTITENANCY_ENABLED === 'true';
+
+  // 4. CONNECTION_CONFIG must not be empty if MULTITENANCY_ENABLED is false
+  if (!isMultiTenancyEnabled && !process.env.CONNECTION_CONFIG) {
+    errors.push('CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is false');
+  }
+
+  // 5. PG_BOSS_CONNECTION_CONFIG must not be empty if DB_TYPE is postgres
+  if (process.env.DB_TYPE === 'postgres' && !process.env.PG_BOSS_CONNECTION_CONFIG) {
+    errors.push('PG_BOSS_CONNECTION_CONFIG must not be empty when DB_TYPE is postgres');
+  }
+
+  // 6. OAUTH2_ISSUERBASEURL must not be empty
+  if (!process.env.OAUTH2_ISSUERBASEURL) {
+    errors.push('OAUTH2_ISSUERBASEURL must not be empty');
+  }
+
+  // 7. OAUTH2_AUDIENCE must not be empty
+  if (!process.env.OAUTH2_AUDIENCE) {
+    errors.push('OAUTH2_AUDIENCE must not be empty');
+  }
+
+  // 8. OAUTH2_TOKENSIGNINGALG must be RS256
+  if (!process.env.OAUTH2_TOKENSIGNINGALG) {
+    errors.push('OAUTH2_TOKENSIGNINGALG must not be empty');
+  } else if (process.env.OAUTH2_TOKENSIGNINGALG !== 'RS256') {
+    errors.push('OAUTH2_TOKENSIGNINGALG must be "RS256"');
+  }
+
+  // 9. OAUTH2_PUBLIC_KEY_PEM must not be empty
+  if (!process.env.OAUTH2_PUBLIC_KEY_PEM) {
+    errors.push('OAUTH2_PUBLIC_KEY_PEM must not be empty');
+  }
+
+  // 10. TENANTS_CONNECTION_CONFIG must not be empty if MULTITENANCY_ENABLED is true
+  if (isMultiTenancyEnabled && !process.env.TENANTS_CONNECTION_CONFIG) {
+    errors.push('TENANTS_CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is true');
+  }
+
+  const isHttpsEnabled = process.env.ENABLE_HTTPS === 'true';
+
+  // 11. TLS_KEY_PATH must not be empty if ENABLE_HTTPS is true
+  if (isHttpsEnabled && !process.env.TLS_KEY_PATH) {
+    errors.push('TLS_KEY_PATH must not be empty when ENABLE_HTTPS is true');
+  }
+
+  // 12. TLS_CERT_PATH must not be empty if ENABLE_HTTPS is true
+  if (isHttpsEnabled && !process.env.TLS_CERT_PATH) {
+    errors.push('TLS_CERT_PATH must not be empty when ENABLE_HTTPS is true');
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors
+  };
+}
+
+/**
+ * Validates environment variables and exits the process if validation fails
+ * Logs all validation errors to the console
+ */
+export function validateAndExit() {
+  const { isValid, errors } = validateEnvironmentVariables();
+
+  if (!isValid) {
+    console.error('\n❌ Environment variable validation failed:\n');
+    errors.forEach((error, index) => {
+      console.error(`  ${index + 1}. ${error}`);
+    });
+    console.error('\n❌ Application startup aborted due to invalid configuration.\n');
+    process.exit(1);
+  }
+
+  console.log('✅ Environment variable validation passed');
+}

--- a/src/utils/envValidator.js
+++ b/src/utils/envValidator.js
@@ -139,13 +139,13 @@ export function validateAndExit() {
   const { isValid, errors } = validateEnvironmentVariables();
 
   if (!isValid) {
-    console.error('\n❌ Environment variable validation failed:\n');
+    console.error('Environment variable validation failed:\n');
     errors.forEach((error, index) => {
       console.error(`  ${index + 1}. ${error}`);
     });
-    console.error('\n❌ Application startup aborted due to invalid configuration.\n');
+    console.error('Application startup aborted due to invalid configuration.\n');
     process.exit(1);
   }
 
-  console.log('✅ Environment variable validation passed');
+  console.log('Environment variable validation passed');
 }

--- a/stack/oneroster-service.yml
+++ b/stack/oneroster-service.yml
@@ -14,6 +14,7 @@ services:
     networks:
       - edfioneroster-network
     environment:
+      PORT: ${PORT:-3000}
       DB_TYPE: ${DB_TYPE:-postgres}
       API_BASE_PATH: ${API_BASE_PATH:-''}
       DB_HOST: ${DB_HOST:-db-ods}
@@ -38,6 +39,7 @@ services:
       TENANTS_CONNECTION_CONFIG: '${TENANTS_CONNECTION_CONFIG}'
       CONNECTION_CONFIG: '${CONNECTION_CONFIG}'
       PG_BOSS_CONNECTION_CONFIG: '${PG_BOSS_CONNECTION_CONFIG}'
+      ODS_CONNECTION_STRING_ENCRYPTION_KEY: '${ODS_CONNECTION_STRING_ENCRYPTION_KEY}'
     hostname: ${ONEROSTER_API_VIRTUAL_NAME}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health-check"]

--- a/tests/unit-tests/envValidator.test.js
+++ b/tests/unit-tests/envValidator.test.js
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to EdTech Consortium, Inc. under one or more agreements.
+// EdTech Consortium, Inc. licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+describe('envValidator', () => {
+  let originalEnv;
+  let validateEnvironmentVariables;
+  let validateAndExit;
+
+  beforeEach(async () => {
+    // Save original environment
+    originalEnv = { ...process.env };
+
+    // Set up a valid default environment
+    process.env.PORT = '3000';
+    process.env.DB_TYPE = 'postgres';
+    process.env.ODS_CONNECTION_STRING_ENCRYPTION_KEY = 'test-key';
+    process.env.CONNECTION_CONFIG = '{"adminConnection": "test"}';
+    process.env.PG_BOSS_CONNECTION_CONFIG = '{"adminConnection": "test"}';
+    process.env.OAUTH2_ISSUERBASEURL = 'https://auth.example.com';
+    process.env.OAUTH2_AUDIENCE = 'https://api.example.com';
+    process.env.OAUTH2_TOKENSIGNINGALG = 'RS256';
+    process.env.OAUTH2_PUBLIC_KEY_PEM = '-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----';
+    process.env.MULTITENANCY_ENABLED = 'false';
+
+    // Import the module
+    const envValidator = await import('../../src/utils/envValidator.js');
+    validateEnvironmentVariables = envValidator.validateEnvironmentVariables;
+    validateAndExit = envValidator.validateAndExit;
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  describe('validateEnvironmentVariables', () => {
+    test('should pass validation with all required variables set correctly', () => {
+      const result = validateEnvironmentVariables();
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    describe('PORT validation', () => {
+      test('should fail if PORT is not set', () => {
+        delete process.env.PORT;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('PORT must not be empty');
+      });
+
+      test('should fail if PORT is empty string', () => {
+        process.env.PORT = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('PORT must not be empty');
+      });
+    });
+
+    describe('DB_TYPE validation', () => {
+      test('should fail if DB_TYPE is not set', () => {
+        delete process.env.DB_TYPE;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('DB_TYPE must not be empty');
+      });
+
+      test('should fail if DB_TYPE is empty string', () => {
+        process.env.DB_TYPE = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('DB_TYPE must not be empty');
+      });
+
+      test('should fail if DB_TYPE is not "mssql" or "postgres"', () => {
+        process.env.DB_TYPE = 'mysql';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('DB_TYPE must be either "mssql" or "postgres"');
+      });
+
+      test('should pass if DB_TYPE is "mssql"', () => {
+        process.env.DB_TYPE = 'mssql';
+        delete process.env.PG_BOSS_CONNECTION_CONFIG; // Not required for mssql
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+
+      test('should pass if DB_TYPE is "postgres"', () => {
+        process.env.DB_TYPE = 'postgres';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('ODS_CONNECTION_STRING_ENCRYPTION_KEY validation', () => {
+      test('should fail if ODS_CONNECTION_STRING_ENCRYPTION_KEY is not set', () => {
+        delete process.env.ODS_CONNECTION_STRING_ENCRYPTION_KEY;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('ODS_CONNECTION_STRING_ENCRYPTION_KEY must not be empty');
+      });
+
+      test('should fail if ODS_CONNECTION_STRING_ENCRYPTION_KEY is empty string', () => {
+        process.env.ODS_CONNECTION_STRING_ENCRYPTION_KEY = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('ODS_CONNECTION_STRING_ENCRYPTION_KEY must not be empty');
+      });
+    });
+
+    describe('CONNECTION_CONFIG validation (single tenancy)', () => {
+      test('should fail if CONNECTION_CONFIG is not set when MULTITENANCY_ENABLED is false', () => {
+        process.env.MULTITENANCY_ENABLED = 'false';
+        delete process.env.CONNECTION_CONFIG;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is false');
+      });
+
+      test('should fail if CONNECTION_CONFIG is empty when MULTITENANCY_ENABLED is false', () => {
+        process.env.MULTITENANCY_ENABLED = 'false';
+        process.env.CONNECTION_CONFIG = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is false');
+      });
+
+      test('should not require CONNECTION_CONFIG when MULTITENANCY_ENABLED is true', () => {
+        process.env.MULTITENANCY_ENABLED = 'true';
+        process.env.TENANTS_CONNECTION_CONFIG = '{"tenant1": {"adminConnection": "test"}}';
+        delete process.env.CONNECTION_CONFIG;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('PG_BOSS_CONNECTION_CONFIG validation', () => {
+      test('should fail if PG_BOSS_CONNECTION_CONFIG is not set when DB_TYPE is postgres', () => {
+        process.env.DB_TYPE = 'postgres';
+        delete process.env.PG_BOSS_CONNECTION_CONFIG;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('PG_BOSS_CONNECTION_CONFIG must not be empty when DB_TYPE is postgres');
+      });
+
+      test('should fail if PG_BOSS_CONNECTION_CONFIG is empty when DB_TYPE is postgres', () => {
+        process.env.DB_TYPE = 'postgres';
+        process.env.PG_BOSS_CONNECTION_CONFIG = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('PG_BOSS_CONNECTION_CONFIG must not be empty when DB_TYPE is postgres');
+      });
+
+      test('should not require PG_BOSS_CONNECTION_CONFIG when DB_TYPE is mssql', () => {
+        process.env.DB_TYPE = 'mssql';
+        delete process.env.PG_BOSS_CONNECTION_CONFIG;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('OAUTH2_ISSUERBASEURL validation', () => {
+      test('should fail if OAUTH2_ISSUERBASEURL is not set', () => {
+        delete process.env.OAUTH2_ISSUERBASEURL;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_ISSUERBASEURL must not be empty');
+      });
+
+      test('should fail if OAUTH2_ISSUERBASEURL is empty string', () => {
+        process.env.OAUTH2_ISSUERBASEURL = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_ISSUERBASEURL must not be empty');
+      });
+    });
+
+    describe('OAUTH2_AUDIENCE validation', () => {
+      test('should fail if OAUTH2_AUDIENCE is not set', () => {
+        delete process.env.OAUTH2_AUDIENCE;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_AUDIENCE must not be empty');
+      });
+
+      test('should fail if OAUTH2_AUDIENCE is empty string', () => {
+        process.env.OAUTH2_AUDIENCE = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_AUDIENCE must not be empty');
+      });
+    });
+
+    describe('OAUTH2_TOKENSIGNINGALG validation', () => {
+      test('should fail if OAUTH2_TOKENSIGNINGALG is not set', () => {
+        delete process.env.OAUTH2_TOKENSIGNINGALG;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_TOKENSIGNINGALG must not be empty');
+      });
+
+      test('should fail if OAUTH2_TOKENSIGNINGALG is empty string', () => {
+        process.env.OAUTH2_TOKENSIGNINGALG = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_TOKENSIGNINGALG must not be empty');
+      });
+
+      test('should fail if OAUTH2_TOKENSIGNINGALG is not "RS256"', () => {
+        process.env.OAUTH2_TOKENSIGNINGALG = 'HS256';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_TOKENSIGNINGALG must be "RS256"');
+      });
+
+      test('should pass if OAUTH2_TOKENSIGNINGALG is "RS256"', () => {
+        process.env.OAUTH2_TOKENSIGNINGALG = 'RS256';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('OAUTH2_PUBLIC_KEY_PEM validation', () => {
+      test('should fail if OAUTH2_PUBLIC_KEY_PEM is not set', () => {
+        delete process.env.OAUTH2_PUBLIC_KEY_PEM;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_PUBLIC_KEY_PEM must not be empty');
+      });
+
+      test('should fail if OAUTH2_PUBLIC_KEY_PEM is empty string', () => {
+        process.env.OAUTH2_PUBLIC_KEY_PEM = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('OAUTH2_PUBLIC_KEY_PEM must not be empty');
+      });
+    });
+
+    describe('TENANTS_CONNECTION_CONFIG validation (multi-tenancy)', () => {
+      test('should fail if TENANTS_CONNECTION_CONFIG is not set when MULTITENANCY_ENABLED is true', () => {
+        process.env.MULTITENANCY_ENABLED = 'true';
+        delete process.env.TENANTS_CONNECTION_CONFIG;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('TENANTS_CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is true');
+      });
+
+      test('should fail if TENANTS_CONNECTION_CONFIG is empty when MULTITENANCY_ENABLED is true', () => {
+        process.env.MULTITENANCY_ENABLED = 'true';
+        process.env.TENANTS_CONNECTION_CONFIG = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('TENANTS_CONNECTION_CONFIG must not be empty when MULTITENANCY_ENABLED is true');
+      });
+
+      test('should not require TENANTS_CONNECTION_CONFIG when MULTITENANCY_ENABLED is false', () => {
+        process.env.MULTITENANCY_ENABLED = 'false';
+        delete process.env.TENANTS_CONNECTION_CONFIG;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('TLS configuration validation (HTTPS)', () => {
+      test('should fail if TLS_KEY_PATH is not set when ENABLE_HTTPS is true', () => {
+        process.env.ENABLE_HTTPS = 'true';
+        delete process.env.TLS_KEY_PATH;
+        process.env.TLS_CERT_PATH = './certs/tls.crt';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('TLS_KEY_PATH must not be empty when ENABLE_HTTPS is true');
+      });
+
+      test('should fail if TLS_KEY_PATH is empty when ENABLE_HTTPS is true', () => {
+        process.env.ENABLE_HTTPS = 'true';
+        process.env.TLS_KEY_PATH = '';
+        process.env.TLS_CERT_PATH = './certs/tls.crt';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('TLS_KEY_PATH must not be empty when ENABLE_HTTPS is true');
+      });
+
+      test('should fail if TLS_CERT_PATH is not set when ENABLE_HTTPS is true', () => {
+        process.env.ENABLE_HTTPS = 'true';
+        process.env.TLS_KEY_PATH = './certs/tls.key';
+        delete process.env.TLS_CERT_PATH;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('TLS_CERT_PATH must not be empty when ENABLE_HTTPS is true');
+      });
+
+      test('should fail if TLS_CERT_PATH is empty when ENABLE_HTTPS is true', () => {
+        process.env.ENABLE_HTTPS = 'true';
+        process.env.TLS_KEY_PATH = './certs/tls.key';
+        process.env.TLS_CERT_PATH = '';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('TLS_CERT_PATH must not be empty when ENABLE_HTTPS is true');
+      });
+
+      test('should fail if both TLS_KEY_PATH and TLS_CERT_PATH are not set when ENABLE_HTTPS is true', () => {
+        process.env.ENABLE_HTTPS = 'true';
+        delete process.env.TLS_KEY_PATH;
+        delete process.env.TLS_CERT_PATH;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('TLS_KEY_PATH must not be empty when ENABLE_HTTPS is true');
+        expect(result.errors).toContain('TLS_CERT_PATH must not be empty when ENABLE_HTTPS is true');
+      });
+
+      test('should not require TLS paths when ENABLE_HTTPS is false', () => {
+        process.env.ENABLE_HTTPS = 'false';
+        delete process.env.TLS_KEY_PATH;
+        delete process.env.TLS_CERT_PATH;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+
+      test('should not require TLS paths when ENABLE_HTTPS is not set', () => {
+        delete process.env.ENABLE_HTTPS;
+        delete process.env.TLS_KEY_PATH;
+        delete process.env.TLS_CERT_PATH;
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+
+      test('should pass when ENABLE_HTTPS is true and both TLS paths are set', () => {
+        process.env.ENABLE_HTTPS = 'true';
+        process.env.TLS_KEY_PATH = './certs/tls.key';
+        process.env.TLS_CERT_PATH = './certs/tls.crt';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('multiple validation errors', () => {
+      test('should return all validation errors when multiple fields are invalid', () => {
+        delete process.env.PORT;
+        delete process.env.DB_TYPE;
+        delete process.env.OAUTH2_AUDIENCE;
+        process.env.OAUTH2_TOKENSIGNINGALG = 'HS256';
+        process.env.ENABLE_HTTPS = 'true';
+        delete process.env.TLS_KEY_PATH;
+
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors.length).toBeGreaterThanOrEqual(5);
+        expect(result.errors).toContain('PORT must not be empty');
+        expect(result.errors).toContain('DB_TYPE must not be empty');
+        expect(result.errors).toContain('OAUTH2_AUDIENCE must not be empty');
+        expect(result.errors).toContain('OAUTH2_TOKENSIGNINGALG must be "RS256"');
+        expect(result.errors).toContain('TLS_KEY_PATH must not be empty when ENABLE_HTTPS is true');
+      });
+    });
+  });
+
+  describe('validateAndExit', () => {
+    test('should not exit when validation passes', () => {
+      const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+      const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      validateAndExit();
+
+      expect(mockExit).not.toHaveBeenCalled();
+      expect(mockConsoleLog).toHaveBeenCalledWith('✅ Environment variable validation passed');
+      expect(mockConsoleError).not.toHaveBeenCalled();
+
+      mockExit.mockRestore();
+      mockConsoleLog.mockRestore();
+      mockConsoleError.mockRestore();
+    });
+
+    test('should exit with code 1 when validation fails', () => {
+      delete process.env.PORT;
+      delete process.env.DB_TYPE;
+
+      const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+      const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      validateAndExit();
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(mockConsoleError).toHaveBeenCalled();
+
+      // Verify error message format
+      const errorCalls = mockConsoleError.mock.calls;
+      const errorMessages = errorCalls.map(call => call[0]).join(' ');
+      expect(errorMessages).toContain('Environment variable validation failed');
+      expect(errorMessages).toContain('PORT must not be empty');
+      expect(errorMessages).toContain('DB_TYPE must not be empty');
+
+      mockExit.mockRestore();
+      mockConsoleError.mockRestore();
+    });
+  });
+});

--- a/tests/unit-tests/envValidator.test.js
+++ b/tests/unit-tests/envValidator.test.js
@@ -46,18 +46,39 @@ describe('envValidator', () => {
     });
 
     describe('PORT validation', () => {
-      test('should fail if PORT is not set', () => {
+      test('should pass if PORT is not set (defaults to 3000)', () => {
         delete process.env.PORT;
         const result = validateEnvironmentVariables();
-        expect(result.isValid).toBe(false);
-        expect(result.errors).toContain('PORT must not be empty');
+        expect(result.isValid).toBe(true);
+        expect(result.errors).not.toContain(expect.stringMatching(/PORT/));
       });
 
-      test('should fail if PORT is empty string', () => {
-        process.env.PORT = '';
+      test('should fail if PORT is not a valid integer', () => {
+        process.env.PORT = 'notanumber';
         const result = validateEnvironmentVariables();
         expect(result.isValid).toBe(false);
-        expect(result.errors).toContain('PORT must not be empty');
+        expect(result.errors).toContain('PORT must be a valid integer between 1 and 65535 if set');
+      });
+
+      test('should fail if PORT is out of range (0)', () => {
+        process.env.PORT = '0';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('PORT must be a valid integer between 1 and 65535 if set');
+      });
+
+      test('should fail if PORT is out of range (65536)', () => {
+        process.env.PORT = '65536';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('PORT must be a valid integer between 1 and 65535 if set');
+      });
+
+      test('should pass if PORT is a valid integer in range', () => {
+        process.env.PORT = '8080';
+        const result = validateEnvironmentVariables();
+        expect(result.isValid).toBe(true);
+        expect(result.errors).not.toContain(expect.stringMatching(/PORT/));
       });
     });
 
@@ -114,6 +135,29 @@ describe('envValidator', () => {
     });
 
     describe('CONNECTION_CONFIG validation (single tenancy)', () => {
+            test('should fail if CONNECTION_CONFIG is not valid JSON', () => {
+              process.env.MULTITENANCY_ENABLED = 'false';
+              process.env.CONNECTION_CONFIG = '{invalidJson:';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors).toContain('CONNECTION_CONFIG must be valid JSON');
+            });
+
+            test('should fail if CONNECTION_CONFIG is missing adminConnection', () => {
+              process.env.MULTITENANCY_ENABLED = 'false';
+              process.env.CONNECTION_CONFIG = '{}';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors).toContain('CONNECTION_CONFIG must contain a non-empty adminConnection property');
+            });
+
+            test('should fail if CONNECTION_CONFIG.adminConnection is empty', () => {
+              process.env.MULTITENANCY_ENABLED = 'false';
+              process.env.CONNECTION_CONFIG = '{"adminConnection": ""}';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors).toContain('CONNECTION_CONFIG must contain a non-empty adminConnection property');
+            });
       test('should fail if CONNECTION_CONFIG is not set when MULTITENANCY_ENABLED is false', () => {
         process.env.MULTITENANCY_ENABLED = 'false';
         delete process.env.CONNECTION_CONFIG;
@@ -140,6 +184,29 @@ describe('envValidator', () => {
     });
 
     describe('PG_BOSS_CONNECTION_CONFIG validation', () => {
+            test('should fail if PG_BOSS_CONNECTION_CONFIG is not valid JSON when DB_TYPE is postgres', () => {
+              process.env.DB_TYPE = 'postgres';
+              process.env.PG_BOSS_CONNECTION_CONFIG = '{invalidJson:';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors).toContain('PG_BOSS_CONNECTION_CONFIG must be valid JSON');
+            });
+
+            test('should fail if PG_BOSS_CONNECTION_CONFIG is missing adminConnection when DB_TYPE is postgres', () => {
+              process.env.DB_TYPE = 'postgres';
+              process.env.PG_BOSS_CONNECTION_CONFIG = '{}';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors).toContain('PG_BOSS_CONNECTION_CONFIG must contain a non-empty adminConnection property');
+            });
+
+            test('should fail if PG_BOSS_CONNECTION_CONFIG.adminConnection is empty when DB_TYPE is postgres', () => {
+              process.env.DB_TYPE = 'postgres';
+              process.env.PG_BOSS_CONNECTION_CONFIG = '{"adminConnection": ""}';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors).toContain('PG_BOSS_CONNECTION_CONFIG must contain a non-empty adminConnection property');
+            });
       test('should fail if PG_BOSS_CONNECTION_CONFIG is not set when DB_TYPE is postgres', () => {
         process.env.DB_TYPE = 'postgres';
         delete process.env.PG_BOSS_CONNECTION_CONFIG;
@@ -242,6 +309,37 @@ describe('envValidator', () => {
     });
 
     describe('TENANTS_CONNECTION_CONFIG validation (multi-tenancy)', () => {
+            test('should fail if TENANTS_CONNECTION_CONFIG is not valid JSON when MULTITENANCY_ENABLED is true', () => {
+              process.env.MULTITENANCY_ENABLED = 'true';
+              process.env.TENANTS_CONNECTION_CONFIG = '{invalidJson:';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors).toContain('TENANTS_CONNECTION_CONFIG must be valid JSON');
+            });
+
+            test('should fail if TENANTS_CONNECTION_CONFIG is not an object when MULTITENANCY_ENABLED is true', () => {
+              process.env.MULTITENANCY_ENABLED = 'true';
+              process.env.TENANTS_CONNECTION_CONFIG = '[]';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors).toContain('TENANTS_CONNECTION_CONFIG must be a JSON object mapping tenant IDs to config objects');
+            });
+
+            test('should fail if a tenant is missing adminConnection', () => {
+              process.env.MULTITENANCY_ENABLED = 'true';
+              process.env.TENANTS_CONNECTION_CONFIG = '{"tenant1": {}}';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors.some(e => e.includes("TENANTS_CONNECTION_CONFIG: tenant 'tenant1' must have a non-empty adminConnection property"))).toBe(true);
+            });
+
+            test('should fail if a tenant has empty adminConnection', () => {
+              process.env.MULTITENANCY_ENABLED = 'true';
+              process.env.TENANTS_CONNECTION_CONFIG = '{"tenant1": {"adminConnection": ""}}';
+              const result = validateEnvironmentVariables();
+              expect(result.isValid).toBe(false);
+              expect(result.errors.some(e => e.includes("TENANTS_CONNECTION_CONFIG: tenant 'tenant1' must have a non-empty adminConnection property"))).toBe(true);
+            });
       test('should fail if TENANTS_CONNECTION_CONFIG is not set when MULTITENANCY_ENABLED is true', () => {
         process.env.MULTITENANCY_ENABLED = 'true';
         delete process.env.TENANTS_CONNECTION_CONFIG;
@@ -349,8 +447,8 @@ describe('envValidator', () => {
 
         const result = validateEnvironmentVariables();
         expect(result.isValid).toBe(false);
-        expect(result.errors.length).toBeGreaterThanOrEqual(5);
-        expect(result.errors).toContain('PORT must not be empty');
+        expect(result.errors.length).toBeGreaterThanOrEqual(4); // PORT is now optional
+        expect(result.errors).not.toContain(expect.stringMatching(/PORT/));
         expect(result.errors).toContain('DB_TYPE must not be empty');
         expect(result.errors).toContain('OAUTH2_AUDIENCE must not be empty');
         expect(result.errors).toContain('OAUTH2_TOKENSIGNINGALG must be "RS256"');
@@ -392,7 +490,8 @@ describe('envValidator', () => {
       const errorCalls = mockConsoleError.mock.calls;
       const errorMessages = errorCalls.map(call => call[0]).join(' ');
       expect(errorMessages).toContain('Environment variable validation failed');
-      expect(errorMessages).toContain('PORT must not be empty');
+      // PORT is now optional, so should not be in errors
+      expect(errorMessages.includes('PORT')).toBe(false);
       expect(errorMessages).toContain('DB_TYPE must not be empty');
 
       mockExit.mockRestore();

--- a/tests/unit-tests/envValidator.test.js
+++ b/tests/unit-tests/envValidator.test.js
@@ -33,8 +33,8 @@ describe('envValidator', () => {
   });
 
   afterEach(() => {
-    // Restore original environment
-    process.env = originalEnv;
+    Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; });
+    Object.assign(process.env, originalEnv);
     jest.restoreAllMocks();
   });
 
@@ -466,7 +466,7 @@ describe('envValidator', () => {
       validateAndExit();
 
       expect(mockExit).not.toHaveBeenCalled();
-      expect(mockConsoleLog).toHaveBeenCalledWith('✅ Environment variable validation passed');
+      expect(mockConsoleLog).toHaveBeenCalledWith('Environment variable validation passed');
       expect(mockConsoleError).not.toHaveBeenCalled();
 
       mockExit.mockRestore();


### PR DESCRIPTION
1. Upfront check for config mismatch
2. Not to return stack trace / html response when .OAUTH2_PUBLIC_KEY_PEM is empty