### PR TITLE
[ONEROSTER-65] Include LEA and school year in academic sessions sourcedId hashes

### DIFF
--- a/standard/4.0.0/artifacts/mssql/core/academic_sessions.sql
+++ b/standard/4.0.0/artifacts/mssql/core/academic_sessions.sql
@@ -180,7 +180,7 @@ BEGIN
         ),
         create_school_year AS (
             SELECT
-                LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(ssy.schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(ssy.localEducationAgencyId AS VARCHAR(20)), '-', CAST(ssy.schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
                 MAX(ses.lastmodifieddate) AS dateLastModified,
                 CONCAT(CAST(ssy.schoolyear - 1 AS NVARCHAR(4)), '-', CAST(ssy.schoolyear AS NVARCHAR(4))) AS title,
@@ -205,7 +205,7 @@ BEGIN
             SELECT
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
-                        CONCAT(CAST(schoolid AS VARCHAR(50)), '-', sessionname)
+                        CONCAT(CAST(schoolid AS VARCHAR(50)), '-', CAST(schoolyear AS VARCHAR(10)), '-', sessionname)
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
@@ -216,8 +216,8 @@ BEGIN
                 CONVERT(NVARCHAR(32), enddate, 23) AS endDate,
                 (SELECT
                     CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32),
-                        HASHBYTES('MD5', CAST(schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                     'academicSession' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS parent,
                 CAST(schoolyear AS NVARCHAR(16)) AS schoolYear,

--- a/standard/4.0.0/artifacts/mssql/core/classes.sql
+++ b/standard/4.0.0/artifacts/mssql/core/classes.sql
@@ -186,13 +186,13 @@ BEGIN
                 (SELECT
                     CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
-                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', section.SessionName)
+                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', CAST(section.SchoolYear AS VARCHAR(10)), '-', section.SessionName)
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2))) AS href,
                     'academicSession' AS type,
                     LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
-                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', section.SessionName)
+                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', CAST(section.SchoolYear AS VARCHAR(10)), '-', section.SessionName)
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2)) AS sourcedId
                  FOR JSON PATH) AS terms,

--- a/standard/4.0.0/artifacts/mssql/core/courses.sql
+++ b/standard/4.0.0/artifacts/mssql/core/courses.sql
@@ -133,8 +133,8 @@ BEGIN
             CASE
                 WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL

--- a/standard/4.0.0/artifacts/mssql/core/courses.sql
+++ b/standard/4.0.0/artifacts/mssql/core/courses.sql
@@ -133,8 +133,8 @@ BEGIN
             CASE
                 WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(COALESCE(crs_school.LocalEducationAgencyId, crs.EducationOrganizationId) AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(COALESCE(crs_school.LocalEducationAgencyId, crs.EducationOrganizationId) AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL
@@ -157,6 +157,7 @@ BEGIN
             crs.EducationOrganizationId AS educationOrganizationId
         FROM course crs
         LEFT JOIN course_offerings ON crs.CourseCode = course_offerings.CourseCode
+        LEFT JOIN edfi.School crs_school ON crs.EducationOrganizationId = crs_school.SchoolId
         ;
 
         SET @RowCount = @@ROWCOUNT;

--- a/standard/4.0.0/artifacts/pgsql/core/academic_sessions.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/academic_sessions.sql
@@ -59,7 +59,7 @@ summarize_school_year as (
 ),
 create_school_year as (
     select
-        md5(ssy.schoolyear::text) as "sourcedId",
+        md5(concat(ssy.localEducationAgencyId::varchar, '-', ssy.schoolyear::text)) as "sourcedId",
         'active' as "status",
         max(ses.lastmodifieddate) as "dateLastModified",
         concat(ssy.schoolyear - 1, '-', ssy.schoolyear) as "title",
@@ -89,6 +89,7 @@ sessions_formatted as (
     select
         md5(concat(
             schoolid::varchar,
+            '-', schoolyear::varchar,
             '-', sessionname::varchar
         )) as "sourcedId",
         'active' as "status",
@@ -98,8 +99,8 @@ sessions_formatted as (
         begindate::date::text as "startDate",
         enddate::date::text as "endDate",
         json_build_object(
-            'href', concat('/academicSessions/', md5(schoolyear::text)),
-            'sourcedId', md5(schoolyear::text),
+            'href', concat('/academicSessions/', md5(concat(sessions.localEducationAgencyid::varchar, '-', schoolyear::text))),
+            'sourcedId', md5(concat(sessions.localEducationAgencyid::varchar, '-', schoolyear::text)),
             'type', 'academicSession'
         ) as "parent",
         schoolyear::text as "schoolYear",

--- a/standard/4.0.0/artifacts/pgsql/core/classes.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/classes.sql
@@ -68,10 +68,12 @@ classes as (
 	    jsonb_build_array(json_build_object(
             'href', concat('/academicSessions/', md5(concat(
                 section.schoolid::varchar,
+                '-', section.schoolyear::varchar,
                 '-', section.sessionname::varchar
             ))),
             'sourcedId', md5(concat(
                 section.schoolid::varchar,
+                '-', section.schoolyear::varchar,
                 '-', section.sessionname::varchar)
             ), -- unique ID constructed from natural key of Ed-Fi Sessions
             'type', 'academicSession'

--- a/standard/4.0.0/artifacts/pgsql/core/courses.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/courses.sql
@@ -27,8 +27,8 @@ select
     CASE
         WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(course_offerings.schoolyear::text)),
-                'sourcedId', md5(course_offerings.schoolyear::text),
+                'href', concat('/academicSessions/', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text))),
+                'sourcedId', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text)),
                 'type', 'academicSession'
             )
         ELSE NULL

--- a/standard/4.0.0/artifacts/pgsql/core/courses.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/courses.sql
@@ -27,8 +27,8 @@ select
     CASE
         WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text))),
-                'sourcedId', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text)),
+                'href', concat('/academicSessions/', md5(concat(COALESCE(crs_school.localEducationAgencyId, crs.educationOrganizationId)::varchar, '-', course_offerings.schoolyear::text))),
+                'sourcedId', md5(concat(COALESCE(crs_school.localEducationAgencyId, crs.educationOrganizationId)::varchar, '-', course_offerings.schoolyear::text)),
                 'type', 'academicSession'
             )
         ELSE NULL
@@ -55,7 +55,9 @@ select
     crs.educationOrganizationId as "educationOrganizationId"
 from course crs
     left join course_offerings
-        on crs.coursecode = course_offerings.coursecode;
+        on crs.coursecode = course_offerings.coursecode
+    left join edfi.school crs_school
+        on crs.educationOrganizationId = crs_school.schoolid;
 
 -- Add an index so the materialized view can be refreshed _concurrently_:
 create index if not exists courses_sourcedid ON oneroster12.courses ("sourcedId");

--- a/standard/5.2.0/artifacts/mssql/core/academic_sessions.sql
+++ b/standard/5.2.0/artifacts/mssql/core/academic_sessions.sql
@@ -180,7 +180,7 @@ BEGIN
         ),
         create_school_year AS (
             SELECT
-                LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(ssy.schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(ssy.localEducationAgencyId AS VARCHAR(20)), '-', CAST(ssy.schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
                 MAX(ses.lastmodifieddate) AS dateLastModified,
                 CONCAT(CAST(ssy.schoolyear - 1 AS NVARCHAR(4)), '-', CAST(ssy.schoolyear AS NVARCHAR(4))) AS title,
@@ -205,7 +205,7 @@ BEGIN
             SELECT
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
-                        CONCAT(CAST(schoolid AS VARCHAR(50)), '-', sessionname)
+                        CONCAT(CAST(schoolid AS VARCHAR(50)), '-', CAST(schoolyear AS VARCHAR(10)), '-', sessionname)
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
@@ -216,8 +216,8 @@ BEGIN
                 CONVERT(NVARCHAR(32), enddate, 23) AS endDate,
                 (SELECT
                     CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32),
-                        HASHBYTES('MD5', CAST(schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                     'academicSession' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS parent,
                 CAST(schoolyear AS NVARCHAR(16)) AS schoolYear,

--- a/standard/5.2.0/artifacts/mssql/core/classes.sql
+++ b/standard/5.2.0/artifacts/mssql/core/classes.sql
@@ -186,13 +186,13 @@ BEGIN
                 (SELECT
                     CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
-                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', section.SessionName)
+                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', CAST(section.SchoolYear AS VARCHAR(10)), '-', section.SessionName)
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2))) AS href,
                     'academicSession' AS type,
                     LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
-                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', section.SessionName)
+                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', CAST(section.SchoolYear AS VARCHAR(10)), '-', section.SessionName)
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2)) AS sourcedId
                  FOR JSON PATH) AS terms,

--- a/standard/5.2.0/artifacts/mssql/core/courses.sql
+++ b/standard/5.2.0/artifacts/mssql/core/courses.sql
@@ -133,8 +133,8 @@ BEGIN
             CASE
                 WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL

--- a/standard/5.2.0/artifacts/mssql/core/courses.sql
+++ b/standard/5.2.0/artifacts/mssql/core/courses.sql
@@ -133,8 +133,8 @@ BEGIN
             CASE
                 WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(COALESCE(crs_school.LocalEducationAgencyId, crs.EducationOrganizationId) AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(COALESCE(crs_school.LocalEducationAgencyId, crs.EducationOrganizationId) AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL
@@ -157,6 +157,7 @@ BEGIN
             crs.EducationOrganizationId AS educationOrganizationId
         FROM course crs
         LEFT JOIN course_offerings ON crs.CourseCode = course_offerings.CourseCode
+        LEFT JOIN edfi.School crs_school ON crs.EducationOrganizationId = crs_school.SchoolId
         ;
 
         SET @RowCount = @@ROWCOUNT;

--- a/standard/5.2.0/artifacts/pgsql/core/academic_sessions.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/academic_sessions.sql
@@ -59,7 +59,7 @@ summarize_school_year as (
 ),
 create_school_year as (
     select
-        md5(ssy.schoolyear::text) as "sourcedId",
+        md5(concat(ssy.localEducationAgencyId::varchar, '-', ssy.schoolyear::text)) as "sourcedId",
         'active' as "status",
         max(ses.lastmodifieddate) as "dateLastModified",
         concat(ssy.schoolyear - 1, '-', ssy.schoolyear) as "title",
@@ -89,6 +89,7 @@ sessions_formatted as (
     select
         md5(concat(
             schoolid::varchar,
+            '-', schoolyear::varchar,
             '-', sessionname::varchar
         )) as "sourcedId",
         'active' as "status",
@@ -98,8 +99,8 @@ sessions_formatted as (
         begindate::date::text as "startDate",
         enddate::date::text as "endDate",
         json_build_object(
-            'href', concat('/academicSessions/', md5(schoolyear::text)),
-            'sourcedId', md5(schoolyear::text),
+            'href', concat('/academicSessions/', md5(concat(sessions.localEducationAgencyid::varchar, '-', schoolyear::text))),
+            'sourcedId', md5(concat(sessions.localEducationAgencyid::varchar, '-', schoolyear::text)),
             'type', 'academicSession'
         ) as "parent",
         schoolyear::text as "schoolYear",

--- a/standard/5.2.0/artifacts/pgsql/core/classes.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/classes.sql
@@ -68,10 +68,12 @@ classes as (
 	    jsonb_build_array(json_build_object(
             'href', concat('/academicSessions/', md5(concat(
                 section.schoolid::varchar,
+                '-', section.schoolyear::varchar,
                 '-', section.sessionname::varchar
             ))),
             'sourcedId', md5(concat(
                 section.schoolid::varchar,
+                '-', section.schoolyear::varchar,
                 '-', section.sessionname::varchar)
             ), -- unique ID constructed from natural key of Ed-Fi Sessions
             'type', 'academicSession'

--- a/standard/5.2.0/artifacts/pgsql/core/courses.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/courses.sql
@@ -27,8 +27,8 @@ select
     CASE
         WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(course_offerings.schoolyear::text)),
-                'sourcedId', md5(course_offerings.schoolyear::text),
+                'href', concat('/academicSessions/', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text))),
+                'sourcedId', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text)),
                 'type', 'academicSession'
             )
         ELSE NULL

--- a/standard/5.2.0/artifacts/pgsql/core/courses.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/courses.sql
@@ -27,8 +27,8 @@ select
     CASE
         WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text))),
-                'sourcedId', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text)),
+                'href', concat('/academicSessions/', md5(concat(COALESCE(crs_school.localEducationAgencyId, crs.educationOrganizationId)::varchar, '-', course_offerings.schoolyear::text))),
+                'sourcedId', md5(concat(COALESCE(crs_school.localEducationAgencyId, crs.educationOrganizationId)::varchar, '-', course_offerings.schoolyear::text)),
                 'type', 'academicSession'
             )
         ELSE NULL
@@ -55,7 +55,9 @@ select
     crs.educationOrganizationId as "educationOrganizationId"
 from course crs
     left join course_offerings
-        on crs.coursecode = course_offerings.coursecode;
+        on crs.coursecode = course_offerings.coursecode
+    left join edfi.school crs_school
+        on crs.educationOrganizationId = crs_school.schoolid;
 
 -- Add an index so the materialized view can be refreshed _concurrently_:
 create index if not exists courses_sourcedid ON oneroster12.courses ("sourcedId");

--- a/standard/MSSQL_materialized_view_conversion.md
+++ b/standard/MSSQL_materialized_view_conversion.md
@@ -120,7 +120,7 @@ BEGIN
     ),
     create_school_year AS (
         SELECT
-            CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS NVARCHAR(16))), 2))) AS sourcedId,
+            CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(localEducationAgencyId AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS sourcedId,
             'active' AS status,
             NULL AS dateLastModified,
             CAST(schoolyear - 1 AS NVARCHAR(4)) + '-' + CAST(schoolyear AS NVARCHAR(4)) AS title,
@@ -139,15 +139,15 @@ BEGIN
     ),
     sessions_formatted AS (
         SELECT
-            CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolid AS NVARCHAR(16)) + '-' + sessionname), 2))) AS sourcedId,
+            CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(schoolid AS VARCHAR(50)), '-', CAST(schoolyear AS VARCHAR(10)), '-', sessionname) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS sourcedId,
             'active' AS status,
             sessions.lastmodifieddate AS dateLastModified,
             termdescriptor.codeValue AS title,
             mappedtermdescriptor.mappedvalue AS type,
             CONVERT(NVARCHAR(32), begindate, 120) AS startDate,
             CONVERT(NVARCHAR(32), enddate, 120) AS endDate,
-            (SELECT '/academicSessions/' + CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS NVARCHAR(16))), 2))) AS href,
-                    CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS NVARCHAR(16))), 2))) AS sourcedId,
+            (SELECT '/academicSessions/' + CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS sourcedId,
                     'academicSession' AS type
              FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS parent,
             CAST(schoolyear AS NVARCHAR(16)) AS schoolYear,


### PR DESCRIPTION
## Problem

In an ODS with multiple LEAs (or data for more than one school year), the sp_refresh_academicsessions stored procedure failed with a primary key violation on oneroster12.academicsessions. The root cause was that sourcedId hashes were computed from inputs that were not unique across an ODS:

- School-year records (type=schoolYear) hashed only schoolYear — all LEAs in the same year produced the same hash. The first LEA's row inserted successfully; every subsequent LEA's row caused a PK collision.
- Term/session records hashed only (schoolId, sessionName) — a school with the same session name in multiple years (e.g. "Fall Semester") produced duplicate hashes.

## Changes
**Platforms:**  pgsql, mssql  
**Versions:** 4.0.0, 5.2.0  

### academic_sessions.sql  
#### Root Fix: Hash Formula Corrections

| Field | Old hash input | New hash input |
|------|----------------|----------------|
| `create_school_year.sourcedId` | `schoolYear` | `localEducationAgencyId + '-' + schoolYear` |
| `sessions_formatted.sourcedId` | `schoolId + '-' + sessionName` | `schoolId + '-' + schoolYear + '-' + sessionName` |
| `sessions_formatted.parent.sourcedId` | `schoolYear` | `localEducationAgencyId + '-' + schoolYear` |

---

### classes.sql  
#### Update: Align terms reference with corrected session sourcedId

| Field | Old hash input | New hash input |
|------|----------------|----------------|
| `terms.sourcedId` | `schoolId + '-' + sessionName` | `schoolId + '-' + schoolYear + '-' + sessionName` |

---

### courses.sql  
#### Update: Align schoolYear reference with corrected school-year sourcedId

| Field | Old hash input | New hash input |
|------|----------------|----------------|
| `schoolYear.sourcedId` | `schoolYear` | `COALESCE(school.localEducationAgencyId, crs.educationOrganizationId) + '-' + schoolYear` |
---
The COALESCE handles both LEA- and school-level courses.