### PR TITLE
[ONEROSTER-65]  Make OneRoster views resilient to ODS data spanning multiple districts and schoolyears

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tests/data/
 .env
 node_modules
 testData/
+.env.heref-test

--- a/standard/4.0.0/artifacts/mssql/core/academic_sessions.sql
+++ b/standard/4.0.0/artifacts/mssql/core/academic_sessions.sql
@@ -180,7 +180,7 @@ BEGIN
         ),
         create_school_year AS (
             SELECT
-                LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(ssy.schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(ssy.localEducationAgencyId AS VARCHAR(20)), '-', CAST(ssy.schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
                 MAX(ses.lastmodifieddate) AS dateLastModified,
                 CONCAT(CAST(ssy.schoolyear - 1 AS NVARCHAR(4)), '-', CAST(ssy.schoolyear AS NVARCHAR(4))) AS title,
@@ -205,7 +205,7 @@ BEGIN
             SELECT
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
-                        CONCAT(CAST(schoolid AS VARCHAR(50)), '-', sessionname)
+                        CONCAT(CAST(schoolid AS VARCHAR(50)), '-', CAST(schoolyear AS VARCHAR(10)), '-', sessionname)
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
@@ -216,8 +216,8 @@ BEGIN
                 CONVERT(NVARCHAR(32), enddate, 23) AS endDate,
                 (SELECT
                     CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32),
-                        HASHBYTES('MD5', CAST(schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                     'academicSession' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS parent,
                 CAST(schoolyear AS NVARCHAR(16)) AS schoolYear,

--- a/standard/4.0.0/artifacts/mssql/core/classes.sql
+++ b/standard/4.0.0/artifacts/mssql/core/classes.sql
@@ -186,13 +186,13 @@ BEGIN
                 (SELECT
                     CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
-                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', section.SessionName)
+                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', CAST(section.SchoolYear AS VARCHAR(10)), '-', section.SessionName)
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2))) AS href,
                     'academicSession' AS type,
                     LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
-                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', section.SessionName)
+                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', CAST(section.SchoolYear AS VARCHAR(10)), '-', section.SessionName)
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2)) AS sourcedId
                  FOR JSON PATH) AS terms,

--- a/standard/4.0.0/artifacts/mssql/core/classes.sql
+++ b/standard/4.0.0/artifacts/mssql/core/classes.sql
@@ -151,6 +151,7 @@ BEGIN
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
                         CONCAT(LOWER(section.LocalCourseCode), '-', CAST(section.SchoolId AS VARCHAR),
+                               '-', CAST(section.SchoolYear AS VARCHAR(10)),
                                '-', LOWER(section.SectionIdentifier), '-', LOWER(section.SessionName))
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,

--- a/standard/4.0.0/artifacts/mssql/core/courses.sql
+++ b/standard/4.0.0/artifacts/mssql/core/courses.sql
@@ -133,8 +133,8 @@ BEGIN
             CASE
                 WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL

--- a/standard/4.0.0/artifacts/mssql/core/courses.sql
+++ b/standard/4.0.0/artifacts/mssql/core/courses.sql
@@ -118,8 +118,11 @@ BEGIN
             SELECT * FROM edfi.Course
         ),
         course_offerings AS (
-          SELECT DISTINCT CourseCode, SchoolYear
+          -- one offering row per course (latest school year wins) so a course
+          -- with offerings in multiple years still yields a single courses row.
+          SELECT CourseCode, MAX(SchoolYear) AS SchoolYear
           FROM edfi.CourseOffering
+          GROUP BY CourseCode
         )
         INSERT INTO #staging_courses
         SELECT

--- a/standard/4.0.0/artifacts/mssql/core/courses.sql
+++ b/standard/4.0.0/artifacts/mssql/core/courses.sql
@@ -133,8 +133,8 @@ BEGIN
             CASE
                 WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(COALESCE(crs_school.LocalEducationAgencyId, crs.EducationOrganizationId) AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(COALESCE(crs_school.LocalEducationAgencyId, crs.EducationOrganizationId) AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL
@@ -157,6 +157,7 @@ BEGIN
             crs.EducationOrganizationId AS educationOrganizationId
         FROM course crs
         LEFT JOIN course_offerings ON crs.CourseCode = course_offerings.CourseCode
+        LEFT JOIN edfi.School crs_school ON crs.EducationOrganizationId = crs_school.SchoolId
         ;
 
         SET @RowCount = @@ROWCOUNT;

--- a/standard/4.0.0/artifacts/mssql/core/enrollments.sql
+++ b/standard/4.0.0/artifacts/mssql/core/enrollments.sql
@@ -143,13 +143,15 @@ BEGIN
         ),
         staff_enrollments_formatted AS (
             SELECT
-                -- DS4: BeginDate is NOT part of the identity for StaffSectionAssociation, so exclude it from sourcedId
+                -- DS4: BeginDate is NOT part of the identity for StaffSectionAssociation;
+                -- SchoolYear IS, so include it to keep the id unique across school years.
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
                         CONCAT(LOWER(staff.StaffUniqueId), '-', LOWER(sections.LocalCourseCode), '-',
-                               CAST(sections.SchoolId AS VARCHAR(50)), '-', LOWER(sections.SectionIdentifier), '-',
+                               CAST(sections.SchoolId AS VARCHAR(50)), '-',
+                               CAST(sections.SchoolYear AS VARCHAR(10)), '-',
+                               LOWER(sections.SectionIdentifier), '-',
                                LOWER(sections.SessionName))
-                        -- BeginDate removed for DS4
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
@@ -158,12 +160,14 @@ BEGIN
                     CONCAT('/classes/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
                             CONCAT(LOWER(sections.LocalCourseCode), '-', CAST(sections.SchoolId AS VARCHAR(50)),
+                                   '-', CAST(sections.SchoolYear AS VARCHAR(10)),
                                    '-', LOWER(sections.SectionIdentifier), '-', LOWER(sections.SessionName))
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2))) AS href,
                     LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
                             CONCAT(LOWER(sections.LocalCourseCode), '-', CAST(sections.SchoolId AS VARCHAR(50)),
+                                   '-', CAST(sections.SchoolYear AS VARCHAR(10)),
                                    '-', LOWER(sections.SectionIdentifier), '-', LOWER(sections.SessionName))
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
@@ -188,9 +192,10 @@ BEGIN
                     staff.StaffUniqueId AS [edfi.naturalKey.staffUniqueId],
                     sections.LocalCourseCode AS [edfi.naturalKey.localCourseCode],
                     sections.SchoolId AS [edfi.naturalKey.schoolId],
+                    sections.SchoolYear AS [edfi.naturalKey.schoolYear],
                     sections.SectionIdentifier AS [edfi.naturalKey.sectionIdentifier],
                     sections.SessionName AS [edfi.naturalKey.sessionName]
-                    -- BeginDate removed from natural key for DS4
+                    -- beginDate not part of StaffSectionAssociation identity in DS4
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS metadata,
                 sections.SchoolId AS educationOrganizationId,
                 ssa.StaffUSI AS participantUSI
@@ -208,7 +213,9 @@ BEGIN
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
                         CONCAT(LOWER(student.StudentUniqueId), '-', LOWER(sections.LocalCourseCode), '-',
-                               CAST(sections.SchoolId AS VARCHAR(50)), '-', LOWER(sections.SectionIdentifier), '-',
+                               CAST(sections.SchoolId AS VARCHAR(50)), '-',
+                               CAST(sections.SchoolYear AS VARCHAR(10)), '-',
+                               LOWER(sections.SectionIdentifier), '-',
                                LOWER(sections.SessionName), '-', CONVERT(VARCHAR(32), ssa.BeginDate, 23))
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
@@ -218,12 +225,14 @@ BEGIN
                     CONCAT('/classes/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
                             CONCAT(LOWER(sections.LocalCourseCode), '-', CAST(sections.SchoolId AS VARCHAR(50)),
+                                   '-', CAST(sections.SchoolYear AS VARCHAR(10)),
                                    '-', LOWER(sections.SectionIdentifier), '-', LOWER(sections.SessionName))
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2))) AS href,
                     LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
                             CONCAT(LOWER(sections.LocalCourseCode), '-', CAST(sections.SchoolId AS VARCHAR(50)),
+                                   '-', CAST(sections.SchoolYear AS VARCHAR(10)),
                                    '-', LOWER(sections.SectionIdentifier), '-', LOWER(sections.SessionName))
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
@@ -248,6 +257,7 @@ BEGIN
                     student.StudentUniqueId AS [edfi.naturalKey.studentUniqueId],
                     sections.LocalCourseCode AS [edfi.naturalKey.localCourseCode],
                     sections.SchoolId AS [edfi.naturalKey.schoolId],
+                    sections.SchoolYear AS [edfi.naturalKey.schoolYear],
                     sections.SectionIdentifier AS [edfi.naturalKey.sectionIdentifier],
                     sections.SessionName AS [edfi.naturalKey.sessionName],
                     ssa.BeginDate AS [edfi.naturalKey.beginDate]

--- a/standard/4.0.0/artifacts/mssql/core/enrollments.sql
+++ b/standard/4.0.0/artifacts/mssql/core/enrollments.sql
@@ -179,8 +179,8 @@ BEGIN
                     'org' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS school,
                 (SELECT
-                    CONCAT('/users/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(staff.StaffUniqueId AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(staff.StaffUniqueId AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                    CONCAT('/users/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT('STA-', CAST(staff.StaffUniqueId AS VARCHAR(256)), '-', CAST(sections.SchoolId AS VARCHAR(20))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT('STA-', CAST(staff.StaffUniqueId AS VARCHAR(256)), '-', CAST(sections.SchoolId AS VARCHAR(20))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                     'user' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS [user],
                 'teacher' AS role,
@@ -244,8 +244,8 @@ BEGIN
                     'org' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS school,
                 (SELECT
-                    CONCAT('/users/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(student.StudentUniqueId AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(student.StudentUniqueId AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                    CONCAT('/users/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT('STU-', CAST(student.StudentUniqueId AS VARCHAR(256)), '-', CAST(sections.SchoolId AS VARCHAR(20))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT('STU-', CAST(student.StudentUniqueId AS VARCHAR(256)), '-', CAST(sections.SchoolId AS VARCHAR(20))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                     'user' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS [user],
                 'student' AS role,

--- a/standard/4.0.0/artifacts/mssql/core/users.sql
+++ b/standard/4.0.0/artifacts/mssql/core/users.sql
@@ -497,7 +497,10 @@ BEGIN
         FROM edfi.Student s
             LEFT JOIN student_email se ON s.StudentUSI = se.StudentUSI AND se.email_rank = 1
             LEFT JOIN student_grade sg ON s.StudentUSI = sg.StudentUSI
-            LEFT JOIN student_orgs so ON s.StudentUSI = so.StudentUSI
+            -- dedupe to one row per (student, school): a student with multiple
+            -- associations to the same school (e.g. re-enrollments) must not
+            -- duplicate the school-keyed user sourcedId.
+            LEFT JOIN (SELECT DISTINCT StudentUSI, SchoolId FROM student_orgs) so ON s.StudentUSI = so.StudentUSI
             LEFT JOIN student_ids si ON s.StudentUSI = si.StudentUSI AND so.SchoolId = si.EducationOrganizationId
             LEFT JOIN student_orgs_agg soa ON s.StudentUSI = soa.StudentUSI
 

--- a/standard/4.0.0/artifacts/mssql/core/users.sql
+++ b/standard/4.0.0/artifacts/mssql/core/users.sql
@@ -173,7 +173,9 @@ BEGIN
                     ssa.StudentUSI,
                     gld.CodeValue as grade_level,
                     ROW_NUMBER() OVER (
-                        PARTITION BY ssa.StudentUSI, ssa.SchoolYear
+                        -- partition by student alone (not student, schoolyear) so a
+                        -- student with enrolments in multiple years yields one user row
+                        PARTITION BY ssa.StudentUSI
                         ORDER BY
                             ssa.EntryDate DESC,
                             ssa.ExitWithdrawDate DESC,

--- a/standard/4.0.0/artifacts/mssql/core/users.sql
+++ b/standard/4.0.0/artifacts/mssql/core/users.sql
@@ -446,8 +446,8 @@ BEGIN
                     CONVERT(
                         VARCHAR(4000),
                         CASE
-                            WHEN seo.EducationOrganizationId IS NOT NULL THEN
-                                'STU-' + CONVERT(VARCHAR(256), s.StudentUniqueId) + '-' + CONVERT(VARCHAR(20), seo.EducationOrganizationId)
+                            WHEN so.SchoolId IS NOT NULL THEN
+                                'STU-' + CONVERT(VARCHAR(256), s.StudentUniqueId) + '-' + CONVERT(VARCHAR(20), so.SchoolId)
                             ELSE
                                 'STU-' + CONVERT(VARCHAR(256), s.StudentUniqueId)
                         END
@@ -456,10 +456,7 @@ BEGIN
                 2
             )) AS sourcedId,
             'active' AS status,
-            CASE
-                WHEN seo.edorg_lmdate IS NOT NULL AND (s.LastModifiedDate IS NULL OR seo.edorg_lmdate > s.LastModifiedDate) THEN seo.edorg_lmdate
-                ELSE s.LastModifiedDate
-            END AS dateLastModified,
+            s.LastModifiedDate AS dateLastModified,
             NULL AS userMasterIdentifier,
             CASE WHEN se.ElectronicMailAddress IS NULL THEN '' ELSE se.ElectronicMailAddress END AS username,
             CASE
@@ -481,7 +478,7 @@ BEGIN
             soa.roles AS roles,
             NULL AS userProfiles,
             CAST(s.StudentUniqueId AS NVARCHAR(256)) AS identifier,
-            seo.EducationOrganizationId AS educationOrganizationId,
+            so.SchoolId AS educationOrganizationId,
             s.StudentUSI AS participantUSI,
             se.ElectronicMailAddress AS email,
             NULL AS sms,
@@ -494,14 +491,14 @@ BEGIN
             NULL AS password,
             JSON_QUERY(
                 '{"edfi":{"resource":"students","naturalKey":{"studentUniqueId":"' + CAST(s.StudentUniqueId AS NVARCHAR(256)) + '"},"educationOrganizationId":' +
-                    ISNULL(CONVERT(VARCHAR(20), seo.EducationOrganizationId), 'null') +
+                    ISNULL(CONVERT(VARCHAR(20), so.SchoolId), 'null') +
                 '}}'
             ) AS metadata
         FROM edfi.Student s
             LEFT JOIN student_email se ON s.StudentUSI = se.StudentUSI AND se.email_rank = 1
             LEFT JOIN student_grade sg ON s.StudentUSI = sg.StudentUSI
-            LEFT JOIN student_edorg seo ON s.StudentUSI = seo.StudentUSI
-            LEFT JOIN student_ids si ON s.StudentUSI = si.StudentUSI AND seo.EducationOrganizationId = si.EducationOrganizationId
+            LEFT JOIN student_orgs so ON s.StudentUSI = so.StudentUSI
+            LEFT JOIN student_ids si ON s.StudentUSI = si.StudentUSI AND so.SchoolId = si.EducationOrganizationId
             LEFT JOIN student_orgs_agg soa ON s.StudentUSI = soa.StudentUSI
 
         UNION ALL

--- a/standard/4.0.0/artifacts/pgsql/core/academic_sessions.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/academic_sessions.sql
@@ -59,7 +59,7 @@ summarize_school_year as (
 ),
 create_school_year as (
     select
-        md5(ssy.schoolyear::text) as "sourcedId",
+        md5(concat(ssy.localEducationAgencyId::varchar, '-', ssy.schoolyear::text)) as "sourcedId",
         'active' as "status",
         max(ses.lastmodifieddate) as "dateLastModified",
         concat(ssy.schoolyear - 1, '-', ssy.schoolyear) as "title",
@@ -89,6 +89,7 @@ sessions_formatted as (
     select
         md5(concat(
             schoolid::varchar,
+            '-', schoolyear::varchar,
             '-', sessionname::varchar
         )) as "sourcedId",
         'active' as "status",
@@ -98,8 +99,8 @@ sessions_formatted as (
         begindate::date::text as "startDate",
         enddate::date::text as "endDate",
         json_build_object(
-            'href', concat('/academicSessions/', md5(schoolyear::text)),
-            'sourcedId', md5(schoolyear::text),
+            'href', concat('/academicSessions/', md5(concat(sessions.localEducationAgencyid::varchar, '-', schoolyear::text))),
+            'sourcedId', md5(concat(sessions.localEducationAgencyid::varchar, '-', schoolyear::text)),
             'type', 'academicSession'
         ) as "parent",
         schoolyear::text as "schoolYear",

--- a/standard/4.0.0/artifacts/pgsql/core/classes.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/classes.sql
@@ -33,9 +33,10 @@ classes as (
 	    md5(concat(
             lower(section.localcoursecode)::varchar,
             '-', section.schoolid::varchar,
+            '-', section.schoolyear::varchar,
             '-', lower(section.sectionidentifier)::varchar,
             '-', lower(section.sessionname)::varchar)
-        ) as "sourcedId", -- unique ID constructed from natural key of Ed-Fi Sections
+        ) as "sourcedId", -- unique ID constructed from natural key of Ed-Fi Sections (incl. SchoolYear)
 	    'active' as "status",
 	    section.lastmodifieddate as "dateLastModified",
 	    case

--- a/standard/4.0.0/artifacts/pgsql/core/classes.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/classes.sql
@@ -68,10 +68,12 @@ classes as (
 	    jsonb_build_array(json_build_object(
             'href', concat('/academicSessions/', md5(concat(
                 section.schoolid::varchar,
+                '-', section.schoolyear::varchar,
                 '-', section.sessionname::varchar
             ))),
             'sourcedId', md5(concat(
                 section.schoolid::varchar,
+                '-', section.schoolyear::varchar,
                 '-', section.sessionname::varchar)
             ), -- unique ID constructed from natural key of Ed-Fi Sessions
             'type', 'academicSession'

--- a/standard/4.0.0/artifacts/pgsql/core/courses.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/courses.sql
@@ -11,8 +11,11 @@ with course as (
     select * from edfi.course
 ),
 course_offerings as (
-    select distinct coursecode, schoolyear
+    -- one offering row per course (latest school year wins) so a course with
+    -- offerings in multiple years still yields a single courses row.
+    select coursecode, max(schoolyear) as schoolyear
     from edfi.courseoffering
+    group by coursecode
 )
 -- property documentation at
 -- https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#Main6p8p2

--- a/standard/4.0.0/artifacts/pgsql/core/courses.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/courses.sql
@@ -27,8 +27,8 @@ select
     CASE
         WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(course_offerings.schoolyear::text)),
-                'sourcedId', md5(course_offerings.schoolyear::text),
+                'href', concat('/academicSessions/', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text))),
+                'sourcedId', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text)),
                 'type', 'academicSession'
             )
         ELSE NULL

--- a/standard/4.0.0/artifacts/pgsql/core/courses.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/courses.sql
@@ -27,8 +27,8 @@ select
     CASE
         WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text))),
-                'sourcedId', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text)),
+                'href', concat('/academicSessions/', md5(concat(COALESCE(crs_school.localEducationAgencyId, crs.educationOrganizationId)::varchar, '-', course_offerings.schoolyear::text))),
+                'sourcedId', md5(concat(COALESCE(crs_school.localEducationAgencyId, crs.educationOrganizationId)::varchar, '-', course_offerings.schoolyear::text)),
                 'type', 'academicSession'
             )
         ELSE NULL
@@ -55,7 +55,9 @@ select
     crs.educationOrganizationId as "educationOrganizationId"
 from course crs
     left join course_offerings
-        on crs.coursecode = course_offerings.coursecode;
+        on crs.coursecode = course_offerings.coursecode
+    left join edfi.school crs_school
+        on crs.educationOrganizationId = crs_school.schoolid;
 
 -- Add an index so the materialized view can be refreshed _concurrently_:
 create index if not exists courses_sourcedid ON oneroster12.courses ("sourcedId");

--- a/standard/4.0.0/artifacts/pgsql/core/enrollments.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/enrollments.sql
@@ -18,14 +18,15 @@ sections as (
 ),
 staff_enrollments_formatted as (
     select
-        -- DS4: BeginDate is NOT part of the identity for StaffSectionAssociation, so exclude it from sourcedId
+        -- DS4: BeginDate is NOT part of the identity for StaffSectionAssociation;
+        -- SchoolYear IS, so include it to keep the id unique across school years.
         md5(concat(
             lower(staff.staffUniqueId)::varchar,
             '-', lower(sections.localcoursecode)::varchar,
             '-', sections.schoolid::varchar,
+            '-', sections.schoolyear::varchar,
             '-', lower(sections.sectionidentifier)::varchar,
             '-', lower(sections.sessionname)::varchar
-            -- beginDate removed for DS4
         )) as "sourcedId", -- unique ID constructed from natural key of Ed-Fi StaffSectionAssociations
         'active' as "status",
         ssa.lastmodifieddate as "dateLastModified",
@@ -33,12 +34,14 @@ staff_enrollments_formatted as (
             'href', concat('/classes/', md5(concat(
                 lower(sections.localcoursecode)::varchar,
                 '-', sections.schoolid::varchar,
+                '-', sections.schoolyear::varchar,
                 '-', lower(sections.sectionidentifier)::varchar,
                 '-', lower(sections.sessionname)::varchar
             ))),
             'sourcedId', md5(concat(
                 lower(sections.localcoursecode)::varchar,
                 '-', sections.schoolid::varchar,
+                '-', sections.schoolyear::varchar,
                 '-', lower(sections.sectionidentifier)::varchar,
                 '-', lower(sections.sessionname)::varchar
             )),
@@ -67,9 +70,10 @@ staff_enrollments_formatted as (
                     'staffUniqueId', staff.staffUniqueId,
                     'localCourseCode', sections.localcoursecode,
                     'schoolId', sections.schoolid,
+                    'schoolYear', sections.schoolyear,
                     'sectionIdentifier', sections.sectionidentifier,
                     'sessionName', sections.sessionname
-                    -- beginDate removed from natural key for DS4
+                    -- beginDate not part of StaffSectionAssociation identity in DS4
                 )
             )
         ) AS metadata
@@ -89,6 +93,7 @@ student_enrollments_formatted as (
             lower(student.studentUniqueId)::varchar,
             '-', lower(sections.localcoursecode)::varchar,
             '-', sections.schoolid::varchar,
+            '-', sections.schoolyear::varchar,
             '-', lower(sections.sectionidentifier)::varchar,
             '-', lower(sections.sessionname)::varchar,
             '-', beginDate::varchar
@@ -99,12 +104,14 @@ student_enrollments_formatted as (
             'href', concat('/classes/', md5(concat(
                 lower(sections.localcoursecode)::varchar,
                 '-', sections.schoolid::varchar,
+                '-', sections.schoolyear::varchar,
                 '-', lower(sections.sectionidentifier)::varchar,
                 '-', lower(sections.sessionname)::varchar
             ))),
             'sourcedId', md5(concat(
                 lower(sections.localcoursecode)::varchar,
                 '-', sections.schoolid::varchar,
+                '-', sections.schoolyear::varchar,
                 '-', lower(sections.sectionidentifier)::varchar,
                 '-', lower(sections.sessionname)::varchar
             )),
@@ -133,6 +140,7 @@ student_enrollments_formatted as (
                     'studentUniqueId', student.studentUniqueId,
                     'localCourseCode', sections.localcoursecode,
                     'schoolId', sections.schoolid,
+                    'schoolYear', sections.schoolyear,
                     'sectionIdentifier', sections.sectionidentifier,
                     'sessionName', sections.sessionname,
                     'beginDate', beginDate

--- a/standard/4.0.0/artifacts/pgsql/core/enrollments.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/enrollments.sql
@@ -48,8 +48,8 @@ staff_enrollments_formatted as (
             'type', 'class'
         ) as "class",
         json_build_object(
-            'href', concat('/users/', md5(staff.staffuniqueid)),
-            'sourcedId', md5(staff.staffuniqueid),
+            'href', concat('/users/', md5(concat('STA-', staff.staffuniqueid::text, '-', sections.schoolid::text))),
+            'sourcedId', md5(concat('STA-', staff.staffuniqueid::text, '-', sections.schoolid::text)),
             'type', 'user'
         ) as "user",
         json_build_object(
@@ -118,8 +118,8 @@ student_enrollments_formatted as (
             'type', 'class'
         ) as "class",
         json_build_object(
-            'href', concat('/users/', md5(student.studentuniqueid)),
-            'sourcedId', md5(student.studentuniqueid),
+            'href', concat('/users/', md5(concat('STU-', student.studentuniqueid::text, '-', sections.schoolid::text))),
+            'sourcedId', md5(concat('STU-', student.studentuniqueid::text, '-', sections.schoolid::text)),
             'type', 'user'
         ) as "user",
         json_build_object(

--- a/standard/4.0.0/artifacts/pgsql/core/users.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/users.sql
@@ -211,7 +211,10 @@ formatted_users_student as (
         on student.studentusi = student_grade.studentusi
     left join student_orgs_agg
         on student.studentusi = student_orgs_agg.studentusi
-    left join student_orgs
+    -- dedupe to one row per (student, school): a student with multiple
+    -- associations to the same school (e.g. re-enrollments) must not
+    -- duplicate the school-keyed user sourcedId.
+    left join (select distinct studentusi, schoolid from student_orgs) student_orgs
         on student.studentusi = student_orgs.studentusi
     left join student_ids
         on student.studentusi = student_ids.studentusi

--- a/standard/4.0.0/artifacts/pgsql/core/users.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/users.sql
@@ -151,18 +151,13 @@ student_grade as (
 formatted_users_student as (
     select
         case
-            when student_edorg.educationOrganizationId is not null then
-                md5(concat('STU-', student.studentUniqueId::text, '-', student_edorg.educationOrganizationId::text))
+            when student_orgs.schoolId is not null then
+                md5(concat('STU-', student.studentUniqueId::text, '-', student_orgs.schoolId::text))
             else
                 student_keys.sourced_id
         end as "sourcedId",
         'active' as "status",
-        case
-            when student_edorg.edorg_lmdate is not null
-                and (student.lastmodifieddate is null or student_edorg.edorg_lmdate > student.lastmodifieddate)
-                then student_edorg.edorg_lmdate
-            else student.lastmodifieddate
-        end as "dateLastModified",
+        student.lastmodifieddate as "dateLastModified",
         null::text as "userMasterIdentifier",
         case when student_email.electronicmailaddress is null then '' else student_email.electronicmailaddress end as "username",
         case when student_ids.ids is not null then
@@ -192,7 +187,7 @@ formatted_users_student as (
         student_orgs_agg.roles AS "roles",
         null as "userProfiles",
         student.studentuniqueid as "identifier",
-        student_edorg.educationOrganizationId as "educationOrganizationId",
+        student_orgs.schoolId as "educationOrganizationId",
         student.studentusi as "participantUSI",
         student_email.electronicmailaddress as "email",
         null::text as "sms",
@@ -206,7 +201,7 @@ formatted_users_student as (
                 'naturalKey', json_build_object(
                     'studentUniqueId', student.studentuniqueid
                 ),
-                'educationOrganizationId', student_edorg.educationOrganizationId
+                'educationOrganizationId', student_orgs.schoolId
             )
         ) AS metadata
     from student
@@ -216,11 +211,11 @@ formatted_users_student as (
         on student.studentusi = student_grade.studentusi
     left join student_orgs_agg
         on student.studentusi = student_orgs_agg.studentusi
-    left join student_edorg
-        on student.studentusi = student_edorg.studentusi
+    left join student_orgs
+        on student.studentusi = student_orgs.studentusi
     left join student_ids
         on student.studentusi = student_ids.studentusi
-        and student_ids.educationOrganizationId = student_edorg.educationOrganizationId
+        and student_ids.educationOrganizationId = student_orgs.schoolId
     left join student_email
         on student.studentusi = student_email.studentusi
     --left join grade_level_xwalk

--- a/standard/4.0.0/artifacts/pgsql/core/users.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/users.sql
@@ -129,10 +129,11 @@ student_grade as (
 	from (
         select
             studentusi,
-            schoolyear,
             gradeleveldescriptor.codevalue as grade_level,
             row_number() over(
-                partition by studentusi, schoolyear
+                -- partition by student alone (not student, schoolyear) so a
+                -- student with enrolments in multiple years yields one user row
+                partition by studentusi
                 order by
                     -- latest entry date
                     entrydate desc,

--- a/standard/5.2.0/artifacts/mssql/core/academic_sessions.sql
+++ b/standard/5.2.0/artifacts/mssql/core/academic_sessions.sql
@@ -180,7 +180,7 @@ BEGIN
         ),
         create_school_year AS (
             SELECT
-                LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(ssy.schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(ssy.localEducationAgencyId AS VARCHAR(20)), '-', CAST(ssy.schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
                 MAX(ses.lastmodifieddate) AS dateLastModified,
                 CONCAT(CAST(ssy.schoolyear - 1 AS NVARCHAR(4)), '-', CAST(ssy.schoolyear AS NVARCHAR(4))) AS title,
@@ -205,7 +205,7 @@ BEGIN
             SELECT
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
-                        CONCAT(CAST(schoolid AS VARCHAR(50)), '-', sessionname)
+                        CONCAT(CAST(schoolid AS VARCHAR(50)), '-', CAST(schoolyear AS VARCHAR(10)), '-', sessionname)
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                 'active' AS status,
@@ -216,8 +216,8 @@ BEGIN
                 CONVERT(NVARCHAR(32), enddate, 23) AS endDate,
                 (SELECT
                     CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32),
-                        HASHBYTES('MD5', CAST(schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                     'academicSession' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS parent,
                 CAST(schoolyear AS NVARCHAR(16)) AS schoolYear,

--- a/standard/5.2.0/artifacts/mssql/core/classes.sql
+++ b/standard/5.2.0/artifacts/mssql/core/classes.sql
@@ -186,13 +186,13 @@ BEGIN
                 (SELECT
                     CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
-                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', section.SessionName)
+                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', CAST(section.SchoolYear AS VARCHAR(10)), '-', section.SessionName)
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2))) AS href,
                     'academicSession' AS type,
                     LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
-                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', section.SessionName)
+                            CONCAT(CAST(section.SchoolId AS VARCHAR), '-', CAST(section.SchoolYear AS VARCHAR(10)), '-', section.SessionName)
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2)) AS sourcedId
                  FOR JSON PATH) AS terms,

--- a/standard/5.2.0/artifacts/mssql/core/classes.sql
+++ b/standard/5.2.0/artifacts/mssql/core/classes.sql
@@ -151,6 +151,7 @@ BEGIN
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
                         CONCAT(LOWER(section.LocalCourseCode), '-', CAST(section.SchoolId AS VARCHAR),
+                               '-', CAST(section.SchoolYear AS VARCHAR(10)),
                                '-', LOWER(section.SectionIdentifier), '-', LOWER(section.SessionName))
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,

--- a/standard/5.2.0/artifacts/mssql/core/courses.sql
+++ b/standard/5.2.0/artifacts/mssql/core/courses.sql
@@ -133,8 +133,8 @@ BEGIN
             CASE
                 WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(course_offerings.SchoolYear AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL

--- a/standard/5.2.0/artifacts/mssql/core/courses.sql
+++ b/standard/5.2.0/artifacts/mssql/core/courses.sql
@@ -118,8 +118,11 @@ BEGIN
             SELECT * FROM edfi.Course
         ),
         course_offerings AS (
-          SELECT DISTINCT CourseCode, SchoolYear
+          -- one offering row per course (latest school year wins) so a course
+          -- with offerings in multiple years still yields a single courses row.
+          SELECT CourseCode, MAX(SchoolYear) AS SchoolYear
           FROM edfi.CourseOffering
+          GROUP BY CourseCode
         )
         INSERT INTO #staging_courses
         SELECT

--- a/standard/5.2.0/artifacts/mssql/core/courses.sql
+++ b/standard/5.2.0/artifacts/mssql/core/courses.sql
@@ -133,8 +133,8 @@ BEGIN
             CASE
                 WHEN course_offerings.SchoolYear IS NOT NULL THEN
                     (SELECT
-                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(crs.EducationOrganizationId AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                        CONCAT('/academicSessions/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(COALESCE(crs_school.LocalEducationAgencyId, crs.EducationOrganizationId) AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                        LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(COALESCE(crs_school.LocalEducationAgencyId, crs.EducationOrganizationId) AS VARCHAR(20)), '-', CAST(course_offerings.SchoolYear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                         'academicSession' AS type
                      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER)
                 ELSE NULL
@@ -157,6 +157,7 @@ BEGIN
             crs.EducationOrganizationId AS educationOrganizationId
         FROM course crs
         LEFT JOIN course_offerings ON crs.CourseCode = course_offerings.CourseCode
+        LEFT JOIN edfi.School crs_school ON crs.EducationOrganizationId = crs_school.SchoolId
         ;
 
         SET @RowCount = @@ROWCOUNT;

--- a/standard/5.2.0/artifacts/mssql/core/enrollments.sql
+++ b/standard/5.2.0/artifacts/mssql/core/enrollments.sql
@@ -145,7 +145,9 @@ BEGIN
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
                         CONCAT(LOWER(staff.StaffUniqueId), '-', LOWER(sections.LocalCourseCode), '-',
-                               CAST(sections.SchoolId AS VARCHAR(50)), '-', LOWER(sections.SectionIdentifier), '-',
+                               CAST(sections.SchoolId AS VARCHAR(50)), '-',
+                               CAST(sections.SchoolYear AS VARCHAR(10)), '-',
+                               LOWER(sections.SectionIdentifier), '-',
                                LOWER(sections.SessionName), '-', CONVERT(VARCHAR(32), ssa.BeginDate, 23))
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
@@ -155,12 +157,14 @@ BEGIN
                     CONCAT('/classes/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
                             CONCAT(LOWER(sections.LocalCourseCode), '-', CAST(sections.SchoolId AS VARCHAR(50)),
+                                   '-', CAST(sections.SchoolYear AS VARCHAR(10)),
                                    '-', LOWER(sections.SectionIdentifier), '-', LOWER(sections.SessionName))
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2))) AS href,
                     LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
                             CONCAT(LOWER(sections.LocalCourseCode), '-', CAST(sections.SchoolId AS VARCHAR(50)),
+                                   '-', CAST(sections.SchoolYear AS VARCHAR(10)),
                                    '-', LOWER(sections.SectionIdentifier), '-', LOWER(sections.SessionName))
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
@@ -187,6 +191,7 @@ BEGIN
                     staff.StaffUniqueId AS [edfi.naturalKey.staffUniqueId],
                     sections.LocalCourseCode AS [edfi.naturalKey.localCourseCode],
                     sections.SchoolId AS [edfi.naturalKey.schoolId],
+                    sections.SchoolYear AS [edfi.naturalKey.schoolYear],
                     sections.SectionIdentifier AS [edfi.naturalKey.sectionIdentifier],
                     sections.SessionName AS [edfi.naturalKey.sessionName],
                     ssa.BeginDate AS [edfi.naturalKey.beginDate]
@@ -204,7 +209,9 @@ BEGIN
                 LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                     CAST(
                         CONCAT(LOWER(student.StudentUniqueId), '-', LOWER(sections.LocalCourseCode), '-',
-                               CAST(sections.SchoolId AS VARCHAR(50)), '-', LOWER(sections.SectionIdentifier), '-',
+                               CAST(sections.SchoolId AS VARCHAR(50)), '-',
+                               CAST(sections.SchoolYear AS VARCHAR(10)), '-',
+                               LOWER(sections.SectionIdentifier), '-',
                                LOWER(sections.SessionName), '-', CONVERT(VARCHAR(32), ssa.BeginDate, 23))
                         AS VARCHAR(MAX)
                     ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
@@ -214,12 +221,14 @@ BEGIN
                     CONCAT('/classes/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
                             CONCAT(LOWER(sections.LocalCourseCode), '-', CAST(sections.SchoolId AS VARCHAR(50)),
+                                   '-', CAST(sections.SchoolYear AS VARCHAR(10)),
                                    '-', LOWER(sections.SectionIdentifier), '-', LOWER(sections.SessionName))
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2))) AS href,
                     LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5',
                         CAST(
                             CONCAT(LOWER(sections.LocalCourseCode), '-', CAST(sections.SchoolId AS VARCHAR(50)),
+                                   '-', CAST(sections.SchoolYear AS VARCHAR(10)),
                                    '-', LOWER(sections.SectionIdentifier), '-', LOWER(sections.SessionName))
                             AS VARCHAR(MAX)
                         ) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
@@ -246,6 +255,7 @@ BEGIN
                     student.StudentUniqueId AS [edfi.naturalKey.studentUniqueId],
                     sections.LocalCourseCode AS [edfi.naturalKey.localCourseCode],
                     sections.SchoolId AS [edfi.naturalKey.schoolId],
+                    sections.SchoolYear AS [edfi.naturalKey.schoolYear],
                     sections.SectionIdentifier AS [edfi.naturalKey.sectionIdentifier],
                     sections.SessionName AS [edfi.naturalKey.sessionName],
                     ssa.BeginDate AS [edfi.naturalKey.beginDate]

--- a/standard/5.2.0/artifacts/mssql/core/enrollments.sql
+++ b/standard/5.2.0/artifacts/mssql/core/enrollments.sql
@@ -176,8 +176,8 @@ BEGIN
                     'org' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS school,
                 (SELECT
-                    CONCAT('/users/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(staff.StaffUniqueId AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(staff.StaffUniqueId AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                    CONCAT('/users/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT('STA-', CAST(staff.StaffUniqueId AS VARCHAR(256)), '-', CAST(sections.SchoolId AS VARCHAR(20))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT('STA-', CAST(staff.StaffUniqueId AS VARCHAR(256)), '-', CAST(sections.SchoolId AS VARCHAR(20))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                     'user' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS [user],
                 sections.SchoolId AS educationOrganizationId,
@@ -240,8 +240,8 @@ BEGIN
                     'org' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS school,
                 (SELECT
-                    CONCAT('/users/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(student.StudentUniqueId AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
-                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(student.StudentUniqueId AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
+                    CONCAT('/users/', LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT('STU-', CAST(student.StudentUniqueId AS VARCHAR(256)), '-', CAST(sections.SchoolId AS VARCHAR(20))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT('STU-', CAST(student.StudentUniqueId AS VARCHAR(256)), '-', CAST(sections.SchoolId AS VARCHAR(20))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2)) AS sourcedId,
                     'user' AS type
                  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS [user],
                 sections.SchoolId AS educationOrganizationId,

--- a/standard/5.2.0/artifacts/mssql/core/users.sql
+++ b/standard/5.2.0/artifacts/mssql/core/users.sql
@@ -501,7 +501,10 @@ BEGIN
         FROM edfi.Student s
             LEFT JOIN student_email se ON s.StudentUSI = se.StudentUSI AND se.email_rank = 1
             LEFT JOIN student_grade sg ON s.StudentUSI = sg.StudentUSI
-            LEFT JOIN student_orgs so ON s.StudentUSI = so.StudentUSI
+            -- dedupe to one row per (student, school): a student with multiple
+            -- associations to the same school (e.g. re-enrollments) must not
+            -- duplicate the school-keyed user sourcedId.
+            LEFT JOIN (SELECT DISTINCT StudentUSI, SchoolId FROM student_orgs) so ON s.StudentUSI = so.StudentUSI
             LEFT JOIN student_ids si ON s.StudentUSI = si.StudentUSI AND so.SchoolId = si.EducationOrganizationId
             LEFT JOIN student_orgs_agg soa ON s.StudentUSI = soa.StudentUSI
 

--- a/standard/5.2.0/artifacts/mssql/core/users.sql
+++ b/standard/5.2.0/artifacts/mssql/core/users.sql
@@ -450,8 +450,8 @@ BEGIN
                     CONVERT(
                         VARCHAR(4000),
                         CASE
-                            WHEN seo.EducationOrganizationId IS NOT NULL THEN
-                                'STU-' + CONVERT(VARCHAR(256), s.StudentUniqueId) + '-' + CONVERT(VARCHAR(20), seo.EducationOrganizationId)
+                            WHEN so.SchoolId IS NOT NULL THEN
+                                'STU-' + CONVERT(VARCHAR(256), s.StudentUniqueId) + '-' + CONVERT(VARCHAR(20), so.SchoolId)
                             ELSE
                                 'STU-' + CONVERT(VARCHAR(256), s.StudentUniqueId)
                         END
@@ -460,10 +460,7 @@ BEGIN
                 2
             )) AS sourcedId,
             'active' AS status,
-            CASE
-                WHEN seo.edorg_lmdate IS NOT NULL AND seo.edorg_lmdate > s.LastModifiedDate THEN seo.edorg_lmdate
-                ELSE s.LastModifiedDate
-            END AS dateLastModified,
+            s.LastModifiedDate AS dateLastModified,
             NULL AS userMasterIdentifier,
             CASE WHEN se.ElectronicMailAddress IS NULL THEN '' ELSE se.ElectronicMailAddress END AS username,
             CASE
@@ -494,18 +491,18 @@ BEGIN
                 ELSE NULL
             END AS grades,
             NULL AS password,
-            seo.EducationOrganizationId AS educationOrganizationId,
+            so.SchoolId AS educationOrganizationId,
             s.StudentUSI AS participantUSI,
             JSON_QUERY(
                 '{"edfi":{"resource":"students","naturalKey":{"studentUniqueId":"' + CAST(s.StudentUniqueId AS NVARCHAR(256)) + '"},"educationOrganizationId":' +
-                    ISNULL(CONVERT(VARCHAR(20), seo.EducationOrganizationId), 'null') +
+                    ISNULL(CONVERT(VARCHAR(20), so.SchoolId), 'null') +
                 '}}'
             ) AS metadata
         FROM edfi.Student s
             LEFT JOIN student_email se ON s.StudentUSI = se.StudentUSI AND se.email_rank = 1
             LEFT JOIN student_grade sg ON s.StudentUSI = sg.StudentUSI
-            LEFT JOIN student_edorg seo ON s.StudentUSI = seo.StudentUSI
-            LEFT JOIN student_ids si ON s.StudentUSI = si.StudentUSI AND seo.EducationOrganizationId = si.EducationOrganizationId
+            LEFT JOIN student_orgs so ON s.StudentUSI = so.StudentUSI
+            LEFT JOIN student_ids si ON s.StudentUSI = si.StudentUSI AND so.SchoolId = si.EducationOrganizationId
             LEFT JOIN student_orgs_agg soa ON s.StudentUSI = soa.StudentUSI
 
         UNION ALL

--- a/standard/5.2.0/artifacts/mssql/core/users.sql
+++ b/standard/5.2.0/artifacts/mssql/core/users.sql
@@ -176,7 +176,9 @@ BEGIN
                     ssa.StudentUSI,
                     gld.CodeValue as grade_level,
                     ROW_NUMBER() OVER (
-                        PARTITION BY ssa.StudentUSI, ssa.SchoolYear
+                        -- partition by student alone (not student, schoolyear) so a
+                        -- student with enrolments in multiple years yields one user row
+                        PARTITION BY ssa.StudentUSI
                         ORDER BY
                             ssa.EntryDate DESC,
                             ssa.ExitWithdrawDate DESC,

--- a/standard/5.2.0/artifacts/pgsql/core/academic_sessions.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/academic_sessions.sql
@@ -59,7 +59,7 @@ summarize_school_year as (
 ),
 create_school_year as (
     select
-        md5(ssy.schoolyear::text) as "sourcedId",
+        md5(concat(ssy.localEducationAgencyId::varchar, '-', ssy.schoolyear::text)) as "sourcedId",
         'active' as "status",
         max(ses.lastmodifieddate) as "dateLastModified",
         concat(ssy.schoolyear - 1, '-', ssy.schoolyear) as "title",
@@ -89,6 +89,7 @@ sessions_formatted as (
     select
         md5(concat(
             schoolid::varchar,
+            '-', schoolyear::varchar,
             '-', sessionname::varchar
         )) as "sourcedId",
         'active' as "status",
@@ -98,8 +99,8 @@ sessions_formatted as (
         begindate::date::text as "startDate",
         enddate::date::text as "endDate",
         json_build_object(
-            'href', concat('/academicSessions/', md5(schoolyear::text)),
-            'sourcedId', md5(schoolyear::text),
+            'href', concat('/academicSessions/', md5(concat(sessions.localEducationAgencyid::varchar, '-', schoolyear::text))),
+            'sourcedId', md5(concat(sessions.localEducationAgencyid::varchar, '-', schoolyear::text)),
             'type', 'academicSession'
         ) as "parent",
         schoolyear::text as "schoolYear",

--- a/standard/5.2.0/artifacts/pgsql/core/classes.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/classes.sql
@@ -33,9 +33,10 @@ classes as (
 	    md5(concat(
             lower(section.localcoursecode)::varchar,
             '-', section.schoolid::varchar,
+            '-', section.schoolyear::varchar,
             '-', lower(section.sectionidentifier)::varchar,
             '-', lower(section.sessionname)::varchar)
-        ) as "sourcedId", -- unique ID constructed from natural key of Ed-Fi Sections
+        ) as "sourcedId", -- unique ID constructed from natural key of Ed-Fi Sections (incl. SchoolYear)
 	    'active' as "status",
 	    section.lastmodifieddate as "dateLastModified",
 	    case

--- a/standard/5.2.0/artifacts/pgsql/core/classes.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/classes.sql
@@ -68,10 +68,12 @@ classes as (
 	    jsonb_build_array(json_build_object(
             'href', concat('/academicSessions/', md5(concat(
                 section.schoolid::varchar,
+                '-', section.schoolyear::varchar,
                 '-', section.sessionname::varchar
             ))),
             'sourcedId', md5(concat(
                 section.schoolid::varchar,
+                '-', section.schoolyear::varchar,
                 '-', section.sessionname::varchar)
             ), -- unique ID constructed from natural key of Ed-Fi Sessions
             'type', 'academicSession'

--- a/standard/5.2.0/artifacts/pgsql/core/courses.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/courses.sql
@@ -11,8 +11,11 @@ with course as (
     select * from edfi.course
 ),
 course_offerings as (
-    select distinct coursecode, schoolyear
+    -- one offering row per course (latest school year wins) so a course with
+    -- offerings in multiple years still yields a single courses row.
+    select coursecode, max(schoolyear) as schoolyear
     from edfi.courseoffering
+    group by coursecode
 )
 -- property documentation at
 -- https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#Main6p8p2

--- a/standard/5.2.0/artifacts/pgsql/core/courses.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/courses.sql
@@ -27,8 +27,8 @@ select
     CASE
         WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(course_offerings.schoolyear::text)),
-                'sourcedId', md5(course_offerings.schoolyear::text),
+                'href', concat('/academicSessions/', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text))),
+                'sourcedId', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text)),
                 'type', 'academicSession'
             )
         ELSE NULL

--- a/standard/5.2.0/artifacts/pgsql/core/courses.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/courses.sql
@@ -27,8 +27,8 @@ select
     CASE
         WHEN course_offerings.schoolyear IS NOT NULL THEN
             json_build_object(
-                'href', concat('/academicSessions/', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text))),
-                'sourcedId', md5(concat(crs.educationOrganizationId::varchar, '-', course_offerings.schoolyear::text)),
+                'href', concat('/academicSessions/', md5(concat(COALESCE(crs_school.localEducationAgencyId, crs.educationOrganizationId)::varchar, '-', course_offerings.schoolyear::text))),
+                'sourcedId', md5(concat(COALESCE(crs_school.localEducationAgencyId, crs.educationOrganizationId)::varchar, '-', course_offerings.schoolyear::text)),
                 'type', 'academicSession'
             )
         ELSE NULL
@@ -55,7 +55,9 @@ select
     crs.educationOrganizationId as "educationOrganizationId"
 from course crs
     left join course_offerings
-        on crs.coursecode = course_offerings.coursecode;
+        on crs.coursecode = course_offerings.coursecode
+    left join edfi.school crs_school
+        on crs.educationOrganizationId = crs_school.schoolid;
 
 -- Add an index so the materialized view can be refreshed _concurrently_:
 create index if not exists courses_sourcedid ON oneroster12.courses ("sourcedId");

--- a/standard/5.2.0/artifacts/pgsql/core/enrollments.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/enrollments.sql
@@ -47,8 +47,8 @@ staff_enrollments_formatted as (
             'type', 'class'
         ) as "class",
         json_build_object(
-            'href', concat('/users/', md5(staff.staffuniqueid)),
-            'sourcedId', md5(staff.staffuniqueid),
+            'href', concat('/users/', md5(concat('STA-', staff.staffuniqueid::text, '-', sections.schoolid::text))),
+            'sourcedId', md5(concat('STA-', staff.staffuniqueid::text, '-', sections.schoolid::text)),
             'type', 'user'
         ) as "user",
         json_build_object(
@@ -116,8 +116,8 @@ student_enrollments_formatted as (
             'type', 'class'
         ) as "class",
         json_build_object(
-            'href', concat('/users/', md5(student.studentuniqueid)),
-            'sourcedId', md5(student.studentuniqueid),
+            'href', concat('/users/', md5(concat('STU-', student.studentuniqueid::text, '-', sections.schoolid::text))),
+            'sourcedId', md5(concat('STU-', student.studentuniqueid::text, '-', sections.schoolid::text)),
             'type', 'user'
         ) as "user",
         json_build_object(

--- a/standard/5.2.0/artifacts/pgsql/core/enrollments.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/enrollments.sql
@@ -22,6 +22,7 @@ staff_enrollments_formatted as (
             lower(staff.staffUniqueId)::varchar,
             '-', lower(sections.localcoursecode)::varchar,
             '-', sections.schoolid::varchar,
+            '-', sections.schoolyear::varchar,
             '-', lower(sections.sectionidentifier)::varchar,
             '-', lower(sections.sessionname)::varchar,
             '-', beginDate::varchar
@@ -32,12 +33,14 @@ staff_enrollments_formatted as (
             'href', concat('/classes/', md5(concat(
                 lower(sections.localcoursecode)::varchar,
                 '-', sections.schoolid::varchar,
+                '-', sections.schoolyear::varchar,
                 '-', lower(sections.sectionidentifier)::varchar,
                 '-', lower(sections.sessionname)::varchar
             ))),
             'sourcedId', md5(concat(
                 lower(sections.localcoursecode)::varchar,
                 '-', sections.schoolid::varchar,
+                '-', sections.schoolyear::varchar,
                 '-', lower(sections.sectionidentifier)::varchar,
                 '-', lower(sections.sessionname)::varchar
             )),
@@ -66,6 +69,7 @@ staff_enrollments_formatted as (
                     'staffUniqueId', staff.staffUniqueId,
                     'localCourseCode', sections.localcoursecode,
                     'schoolId', sections.schoolid,
+                    'schoolYear', sections.schoolyear,
                     'sectionIdentifier', sections.sectionidentifier,
                     'sessionName', sections.sessionname,
                     'beginDate', beginDate
@@ -87,6 +91,7 @@ student_enrollments_formatted as (
             lower(student.studentUniqueId)::varchar,
             '-', lower(sections.localcoursecode)::varchar,
             '-', sections.schoolid::varchar,
+            '-', sections.schoolyear::varchar,
             '-', lower(sections.sectionidentifier)::varchar,
             '-', lower(sections.sessionname)::varchar,
             '-', beginDate::varchar
@@ -97,12 +102,14 @@ student_enrollments_formatted as (
             'href', concat('/classes/', md5(concat(
                 lower(sections.localcoursecode)::varchar,
                 '-', sections.schoolid::varchar,
+                '-', sections.schoolyear::varchar,
                 '-', lower(sections.sectionidentifier)::varchar,
                 '-', lower(sections.sessionname)::varchar
             ))),
             'sourcedId', md5(concat(
                 lower(sections.localcoursecode)::varchar,
                 '-', sections.schoolid::varchar,
+                '-', sections.schoolyear::varchar,
                 '-', lower(sections.sectionidentifier)::varchar,
                 '-', lower(sections.sessionname)::varchar
             )),
@@ -131,6 +138,7 @@ student_enrollments_formatted as (
                     'studentUniqueId', student.studentUniqueId,
                     'localCourseCode', sections.localcoursecode,
                     'schoolId', sections.schoolid,
+                    'schoolYear', sections.schoolyear,
                     'sectionIdentifier', sections.sectionidentifier,
                     'sessionName', sections.sessionname,
                     'beginDate', beginDate

--- a/standard/5.2.0/artifacts/pgsql/core/users.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/users.sql
@@ -200,7 +200,10 @@ formatted_users_student as (
         on student.studentusi = student_grade.studentusi
     left join student_orgs_agg
         on student.studentusi = student_orgs_agg.studentusi
-    left join student_orgs
+    -- dedupe to one row per (student, school): a student with multiple
+    -- associations to the same school (e.g. re-enrollments) must not
+    -- duplicate the school-keyed user sourcedId.
+    left join (select distinct studentusi, schoolid from student_orgs) student_orgs
         on student.studentusi = student_orgs.studentusi
     left join student_ids
         on student.studentusi = student_ids.studentusi

--- a/standard/5.2.0/artifacts/pgsql/core/users.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/users.sql
@@ -143,17 +143,12 @@ formatted_users_student as (
     select
         md5(
             case
-                when student_edorg.educationOrganizationId is null then concat('STU-', student.studentUniqueId::text)
-                else concat('STU-', student.studentUniqueId::text, '-', student_edorg.educationOrganizationId::text)
+                when student_orgs.schoolId is null then concat('STU-', student.studentUniqueId::text)
+                else concat('STU-', student.studentUniqueId::text, '-', student_orgs.schoolId::text)
             end
           ) as "sourcedId",
             'active' as "status",
-            case
-                when student_edorg.edorg_lmdate is not null
-                     and (student.lastmodifieddate is null or student_edorg.edorg_lmdate > student.lastmodifieddate)
-                    then student_edorg.edorg_lmdate
-                else student.lastmodifieddate
-            end as "dateLastModified",
+            student.lastmodifieddate as "dateLastModified",
         null::text as "userMasterIdentifier",
         case when student_email.electronicmailaddress is null then '' else student_email.electronicmailaddress end as "username",
         case when student_ids.ids is not null then
@@ -183,7 +178,7 @@ formatted_users_student as (
         student_orgs_agg.roles AS "roles",
         null as "userProfiles",
         student.studentuniqueid as "identifier",
-            student_edorg.educationOrganizationId as "educationOrganizationId",
+            student_orgs.schoolId as "educationOrganizationId",
         student.studentusi as "participantUSI",
         student_email.electronicmailaddress as "email",
         null::text as "sms",
@@ -197,7 +192,7 @@ formatted_users_student as (
                 'naturalKey', json_build_object(
                     'studentUniqueId', student.studentuniqueid
                 ),
-                'educationOrganizationId', student_edorg.educationOrganizationId
+                'educationOrganizationId', student_orgs.schoolId
             )
         ) AS metadata
     from student
@@ -205,11 +200,11 @@ formatted_users_student as (
         on student.studentusi = student_grade.studentusi
     left join student_orgs_agg
         on student.studentusi = student_orgs_agg.studentusi
-    left join student_edorg
-        on student.studentusi = student_edorg.studentusi
+    left join student_orgs
+        on student.studentusi = student_orgs.studentusi
     left join student_ids
         on student.studentusi = student_ids.studentusi
-        and student_ids.educationOrganizationId = student_edorg.educationOrganizationId
+        and student_ids.educationOrganizationId = student_orgs.schoolId
     left join student_email
         on student.studentusi = student_email.studentusi
 ),

--- a/standard/5.2.0/artifacts/pgsql/core/users.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/users.sql
@@ -123,10 +123,11 @@ student_grade as (
     from (
         select
             studentusi,
-            schoolyear,
             gradeleveldescriptor.codevalue as grade_level,
             row_number() over(
-                partition by studentusi, schoolyear
+                -- partition by student alone (not student, schoolyear) so a
+                -- student with enrolments in multiple years yields one user row
+                partition by studentusi
                 order by
                     entrydate desc,
                     exitwithdrawdate desc nulls first,

--- a/standard/MSSQL_materialized_view_conversion.md
+++ b/standard/MSSQL_materialized_view_conversion.md
@@ -120,7 +120,7 @@ BEGIN
     ),
     create_school_year AS (
         SELECT
-            CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS NVARCHAR(16))), 2))) AS sourcedId,
+            CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(localEducationAgencyId AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS sourcedId,
             'active' AS status,
             NULL AS dateLastModified,
             CAST(schoolyear - 1 AS NVARCHAR(4)) + '-' + CAST(schoolyear AS NVARCHAR(4)) AS title,
@@ -139,15 +139,15 @@ BEGIN
     ),
     sessions_formatted AS (
         SELECT
-            CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolid AS NVARCHAR(16)) + '-' + sessionname), 2))) AS sourcedId,
+            CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(schoolid AS VARCHAR(50)), '-', CAST(schoolyear AS VARCHAR(10)), '-', sessionname) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS sourcedId,
             'active' AS status,
             sessions.lastmodifieddate AS dateLastModified,
             termdescriptor.codeValue AS title,
             mappedtermdescriptor.mappedvalue AS type,
             CONVERT(NVARCHAR(32), begindate, 120) AS startDate,
             CONVERT(NVARCHAR(32), enddate, 120) AS endDate,
-            (SELECT '/academicSessions/' + CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS NVARCHAR(16))), 2))) AS href,
-                    CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(schoolyear AS NVARCHAR(16))), 2))) AS sourcedId,
+            (SELECT '/academicSessions/' + CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS href,
+                    CONVERT(NVARCHAR(64), LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', CAST(CONCAT(CAST(sessions.localEducationAgencyid AS VARCHAR(20)), '-', CAST(schoolyear AS VARCHAR(10))) AS VARCHAR(MAX)) COLLATE Latin1_General_BIN), 2))) AS sourcedId,
                     'academicSession' AS type
              FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS parent,
             CAST(schoolyear AS NVARCHAR(16)) AS schoolYear,

--- a/tests/.env.href-test.example
+++ b/tests/.env.href-test.example
@@ -1,0 +1,34 @@
+# =============================================================================
+# href-integrity.js — Connection Configuration
+# =============================================================================
+#
+# Copy this file to tests/.env.href-test and fill in your values:
+#
+#   cp tests/.env.href-test.example tests/.env.href-test
+#
+# DB_CLIENT selects the database engine.
+# Fill in the section that matches your engine and leave the other commented out.
+# =============================================================================
+
+# Which engine to use: 'pg' (PostgreSQL) or 'mssql'
+DB_CLIENT=pg
+
+# How many rows to sample per table when checking hrefs (default: 15000)
+# SAMPLE_LIMIT=15000
+
+# ─── PostgreSQL ───────────────────────────────────────────────────────────────
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=EdFi_Ods
+DB_USER=postgres
+DB_PASS=<your_db_password>
+DB_SSL=false
+
+# ─── MSSQL (uncomment and set DB_CLIENT=mssql) ───────────────────────────────
+# DB_HOST=localhost
+# DB_PORT=1433
+# DB_NAME=EdFi_Ods
+# DB_USER=sa
+# DB_PASS=<your_db_password>
+# DB_ENCRYPT=false
+# DB_TRUST_SERVER_CERTIFICATE=true

--- a/tests/href-integrity.js
+++ b/tests/href-integrity.js
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to EdTech Consortium, Inc. under one or more agreements.
+// EdTech Consortium, Inc. licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+/**
+ * OneRoster Resource href Integrity Test
+ *
+ * Verifies that JSON link columns (class, school, user, course, org, terms, parent, etc.)
+ * in the oneroster12 schema contain href values whose embedded sourcedId actually exists
+ * in the target resource table.
+ *
+ * Usage:
+ *   node tests/href-integrity.js
+ *
+ * Connection is configured via tests/.env.href-test  (copy from tests/.env.href-test.example).
+ * Supports both PostgreSQL (DB_CLIENT=pg) and MSSQL (DB_CLIENT=mssql).
+ */
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Load .env.href-test from the tests/ directory
+const dotenv = require('dotenv');
+dotenv.config({ path: path.join(__dirname, '.env.href-test') });
+
+const knex = require('knex');
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+const DB_CLIENT = process.env.DB_CLIENT || 'pg'; // 'pg' or 'mssql'
+const SAMPLE_LIMIT = parseInt(process.env.SAMPLE_LIMIT) || 200; // rows to sample per table
+
+function buildKnexConfig() {
+    if (DB_CLIENT === 'pg') {
+        return {
+            client: 'pg',
+            connection: {
+                host: process.env.DB_HOST || 'localhost',
+                port: parseInt(process.env.DB_PORT) || 5432,
+                database: process.env.DB_NAME,
+                user: process.env.DB_USER,
+                password: process.env.DB_PASS,
+                ssl: process.env.DB_SSL === 'true'
+            }
+        };
+    }
+
+    // MSSQL
+    return {
+        client: 'mssql',
+        connection: {
+            server: process.env.DB_HOST || 'localhost',
+            port: parseInt(process.env.DB_PORT) || 1433,
+            database: process.env.DB_NAME,
+            user: process.env.DB_USER,
+            password: process.env.DB_PASS,
+            options: {
+                encrypt: process.env.DB_ENCRYPT === 'true',
+                trustServerCertificate: process.env.DB_TRUST_SERVER_CERTIFICATE !== 'false'
+            }
+        }
+    };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a JSON field that may already be an object (PostgreSQL) or a string (MSSQL).
+ */
+function parseJson(value) {
+    if (!value) return null;
+    if (typeof value === 'object') return value;
+    try { return JSON.parse(value); } catch { return null; }
+}
+
+/**
+ * Extract the sourcedId embedded inside an href string: /resource/SOURCEDID
+ */
+function sourcedIdFromHref(href) {
+    if (!href || typeof href !== 'string') return null;
+    const parts = href.split('/');
+    return parts[parts.length - 1] || null;
+}
+
+/**
+ * Fetch all sourcedId values (up to SAMPLE_LIMIT) from a table as a Set.
+ */
+async function fetchSourcedIds(db, table) {
+    const rows = await db('oneroster12.' + table)
+        .select('sourcedId')
+        .limit(SAMPLE_LIMIT * 10); // wider net so referenced IDs are likely present
+
+    return new Set(rows.map(r => r.sourcedId ?? r.sourcedid));
+}
+
+// ─── Individual link checkers ─────────────────────────────────────────────────
+
+/**
+ * Test one JSON link column on a table.
+ *
+ * @param {object} db           - Knex instance
+ * @param {string} sourceTable  - oneroster12 table name
+ * @param {string} jsonColumn   - column name holding the JSON link (or array of links)
+ * @param {string} targetTable  - oneroster12 table the href should resolve into
+ * @param {boolean} isArray     - true when the column holds a JSON array of link objects
+ * @returns {object} result summary
+ */
+async function checkHrefColumn(db, sourceTable, jsonColumn, targetTable, isArray = false) {
+    const label = `${sourceTable}.${jsonColumn} → ${targetTable}`;
+
+    // Sample rows that have the column populated
+    let query = db('oneroster12.' + sourceTable)
+        .select('sourcedId', jsonColumn)
+        .whereNotNull(jsonColumn)
+        .limit(SAMPLE_LIMIT);
+
+    // Knex column names must be quoted for mixed-case PostgreSQL columns
+    const rows = await query;
+
+    if (rows.length === 0) {
+        return { label, status: 'SKIP', detail: 'no rows with this column populated' };
+    }
+
+    const targetIds = await fetchSourcedIds(db, targetTable);
+
+    let checked = 0;
+    const broken = [];
+
+    for (const row of rows) {
+        const raw = row[jsonColumn] ?? row[jsonColumn.toLowerCase()];
+        const parsed = parseJson(raw);
+        if (!parsed) continue;
+
+        const links = isArray ? (Array.isArray(parsed) ? parsed : [parsed]) : [parsed];
+
+        for (const link of links) {
+            if (!link || typeof link !== 'object') continue;
+            const href = link.href;
+            const linkedId = sourcedIdFromHref(href);
+            checked++;
+
+            if (!linkedId) {
+                broken.push({ sourceId: row.sourcedId ?? row.sourcedid, href, reason: 'no sourcedId in href' });
+                continue;
+            }
+
+            // Also verify the sourcedId field embedded in the link object matches the href
+            const embeddedId = link.sourcedId ?? link.sourcedid;
+            if (embeddedId && embeddedId !== linkedId) {
+                broken.push({
+                    sourceId: row.sourcedId ?? row.sourcedid,
+                    href,
+                    reason: `href sourcedId (${linkedId}) ≠ link.sourcedId (${embeddedId})`
+                });
+                continue;
+            }
+
+            if (!targetIds.has(linkedId)) {
+                broken.push({ sourceId: row.sourcedId ?? row.sourcedid, href, reason: 'target record not found' });
+            }
+        }
+    }
+
+    if (broken.length === 0) {
+        return { label, status: 'PASS', checked };
+    }
+    return { label, status: 'FAIL', checked, broken: broken.slice(0, 10) }; // cap output
+}
+
+// ─── Test definitions ─────────────────────────────────────────────────────────
+
+/**
+ * All href link relationships across oneroster12 resources.
+ * Each entry: [sourceTable, jsonColumn, targetTable, isArray]
+ */
+const HREF_CHECKS = [
+    // enrollments
+    ['enrollments', 'class',   'classes',          false],
+    ['enrollments', 'user',    'users',             false],
+    ['enrollments', 'school',  'orgs',              false],
+
+    // classes
+    ['classes',     'course',  'courses',           false],
+    ['classes',     'school',  'orgs',              false],
+    ['classes',     'terms',   'academicsessions',  true],  // array
+
+    // courses
+    ['courses',     'org',        'orgs',             false],
+    ['courses',     'schoolYear', 'academicsessions', false],
+
+    // academicSessions — term sessions link up to their parent school-year session
+    ['academicsessions', 'parent', 'academicsessions', false],
+
+    // orgs — school links to parent LEA, LEA links to parent SEA
+    ['orgs', 'parent', 'orgs', false],
+
+    // users — org links are nested inside roles[].org (not a top-level column)
+    // Handled separately by checkUsersRolesOrgs() below.
+];
+
+/**
+ * Special check: users.roles[*].org → orgs
+ * The `roles` column holds a JSON array of role objects; each role has an `org`
+ * sub-object with `href` and `sourcedId`.
+ */
+async function checkUsersRolesOrgs(db) {
+    const label = 'users.roles[].org → orgs';
+
+    const rows = await db('oneroster12.users')
+        .select('sourcedId', 'roles')
+        .whereNotNull('roles')
+        .limit(SAMPLE_LIMIT);
+
+    if (rows.length === 0) {
+        return { label, status: 'SKIP', detail: 'no rows with roles populated' };
+    }
+
+    const targetIds = await fetchSourcedIds(db, 'orgs');
+    let checked = 0;
+    const broken = [];
+
+    for (const row of rows) {
+        const roles = parseJson(row.roles ?? row.Roles);
+        if (!Array.isArray(roles)) continue;
+        for (const role of roles) {
+            if (!role || typeof role !== 'object') continue;
+            const org = role.org;
+            if (!org || typeof org !== 'object') continue;
+            const href = org.href;
+            const linkedId = sourcedIdFromHref(href);
+            checked++;
+
+            if (!linkedId) {
+                broken.push({ sourceId: row.sourcedId ?? row.sourcedid, href, reason: 'no sourcedId in href' });
+                continue;
+            }
+            const embeddedId = org.sourcedId ?? org.sourcedid;
+            if (embeddedId && embeddedId !== linkedId) {
+                broken.push({ sourceId: row.sourcedId ?? row.sourcedid, href,
+                    reason: `href sourcedId (${linkedId}) ≠ org.sourcedId (${embeddedId})` });
+                continue;
+            }
+            if (!targetIds.has(linkedId)) {
+                broken.push({ sourceId: row.sourcedId ?? row.sourcedid, href, reason: 'target record not found' });
+            }
+        }
+    }
+
+    if (broken.length === 0) return { label, status: 'PASS', checked };
+    return { label, status: 'FAIL', checked, broken: broken.slice(0, 10) };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+    const db = knex(buildKnexConfig());
+
+    console.log(`\nOneRoster href Integrity Test`);
+    console.log(`DB engine : ${DB_CLIENT}`);
+    console.log(`DB host   : ${process.env.DB_HOST}`);
+    console.log(`DB name   : ${process.env.DB_NAME}`);
+    console.log(`Sample cap: ${SAMPLE_LIMIT} rows per table\n`);
+    console.log('─'.repeat(70));
+
+    const results = [];
+    let passed = 0, failed = 0, skipped = 0;
+
+    // Add the nested roles[].org check after the standard checks
+    const allChecks = [
+        ...HREF_CHECKS.map(([s, c, t, a]) => ({ type: 'standard', args: [s, c, t, a] })),
+        { type: 'usersRolesOrgs' }
+    ];
+
+    for (const check of allChecks) {
+    if (check.type === 'usersRolesOrgs') {
+        process.stdout.write(`Checking users.roles[].org → orgs ... `);
+        try {
+            const result = await checkUsersRolesOrgs(db);
+            results.push(result);
+            if (result.status === 'PASS') { passed++; console.log(`PASS  (${result.checked} links checked)`); }
+            else if (result.status === 'FAIL') { failed++; console.log(`FAIL  (${result.broken.length} broken out of ${result.checked} checked)`); for (const b of result.broken) console.log(`  source=${b.sourceId}  href=${b.href}  reason=${b.reason}`); }
+            else { skipped++; console.log(`SKIP  (${result.detail})`); }
+        } catch (err) { failed++; console.log(`ERROR  ${err.message}`); }
+        continue;
+    }
+    const [sourceTable, jsonColumn, targetTable, isArray] = check.args;
+        process.stdout.write(`Checking ${sourceTable}.${jsonColumn} → ${targetTable} ... `);
+        try {
+            const result = await checkHrefColumn(db, sourceTable, jsonColumn, targetTable, isArray);
+            results.push(result);
+
+            if (result.status === 'PASS') {
+                passed++;
+                console.log(`PASS  (${result.checked} links checked)`);
+            } else if (result.status === 'FAIL') {
+                failed++;
+                console.log(`FAIL  (${result.broken.length} broken out of ${result.checked} checked)`);
+                for (const b of result.broken) {
+                    console.log(`source=${b.sourceId}  href=${b.href}  reason=${b.reason}`);
+                }
+            } else {
+                skipped++;
+                console.log(`SKIP  (${result.detail})`);
+            }
+        } catch (err) {
+            failed++;
+            console.log(`ERROR  ${err.message}`);
+            results.push({ label: `${sourceTable}.${jsonColumn} → ${targetTable}`, status: 'ERROR', error: err.message });
+        }
+    } // end for allChecks
+
+    console.log('\n' + '─'.repeat(70));
+    console.log(`Results: ${passed} passed, ${failed} failed, ${skipped} skipped`);
+    console.log('─'.repeat(70) + '\n');
+
+    await db.destroy();
+    process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+    console.error('Fatal:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
 These changes make the OneRoster views tolerant of an ODS that contains more than one school year of data. The Ed-Fi API performs no validation that incoming data belongs to the "current" year, and there is a possibility of  prior-year records landing in the ODS, as seen in some UAT environments. When multiple years are present, several view sourcedIds — derived from hash inputs that weren't unique across years — produced duplicate keys and failed the PK/unique index on refresh. This PR makes those sourcedIds structurally unique by folding the missing natural-key components into them. ---
### AcademicSessions

| Record | Old sourcedId inputs | New sourcedId inputs |
|--------|---------------------|---------------------|
| school-year row | schoolYear | LEA + schoolYear |
| term / session row | schoolId + sessionName | schoolId + schoolYear + sessionName |
| parent ref (term → school-year) | schoolYear | LEA + schoolYear |

---

### Classes

| Record | Old | New |
|--------|-----|-----|
| class sourcedId | localCourseCode + schoolId + sectionIdentifier + sessionName | localCourseCode + schoolId + schoolYear + sectionIdentifier + sessionName |
| terms[].academicSession ref | schoolId + sessionName | schoolId + schoolYear + sessionName |

---

### Courses

| Record | Old | New |
|--------|-----|-----|
| course sourcedId | educationOrganizationId + courseCode | unchanged (course is year-agnostic; collisions handled by deduping offerings) |
| schoolYear (academicSession ref) | schoolYear | LEA + schoolYear |

---

### Enrollments

| Record | Old | New |
|--------|-----|-----|
| staff sourcedId (DS 5.2.0) | staffUniqueId + localCourseCode + schoolId + sectionIdentifier + sessionName + beginDate | staffUniqueId + localCourseCode + schoolId + schoolYear + sectionIdentifier + sessionName + beginDate |
| staff sourcedId (DS 4.0.0) | staffUniqueId + localCourseCode + schoolId + sectionIdentifier + sessionName | staffUniqueId + localCourseCode + schoolId + schoolYear + sectionIdentifier + sessionName |
| student sourcedId (both DS) | studentUniqueId + localCourseCode + schoolId + sectionIdentifier + sessionName + beginDate | studentUniqueId + localCourseCode + schoolId + schoolYear + sectionIdentifier + sessionName + beginDate |
| class ref | localCourseCode + schoolId + sectionIdentifier + sessionName | localCourseCode + schoolId + schoolYear + sectionIdentifier + sessionName |
| user ref (staff) | staffUniqueId | `STA-` + staffUniqueId + schoolId |
| user ref (student) | studentUniqueId | `STU-` + studentUniqueId + schoolId |

---
### users

| Record                | Old                                                                 | New                                                                 |
|----------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|
| student sourcedId    | `'STU-' + studentUniqueId [+ educationOrganizationId]` — ed-org from StudentEducationOrganizationAssociation (can be an LEA); ed-org omitted when null | `'STU-' + studentUniqueId [+ schoolId]` — school from StudentSchoolAssociation, deduped to one row per (student, school); school omitted when null |
| staff sourcedId      | `'STA-' + staffUniqueId [+ primary schoolId]`                         | unchanged                                                           |
| parent/contact sourcedId | `'PAR-' + contactUniqueId [+ schoolId]`                           | unchanged                                                           |
