### PR TITLE
[ONEROSTER-101] Add file-based plugin examples for tenants and app-secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ DB_TYPE=postgres
 
 # Optional: load ODS encryption key + JWT public PEM from a plugin instead of the two variables below.
 # Set APP_SECRETS_MODULE to enable (see docs/app-secrets-plugin.md).
+# Example file-based plugin (reference only); APP_SECRETS_FILE is read by this plugin, not core:
+# APP_SECRETS_MODULE=./src/config/examples/app-secrets-file.js
+# APP_SECRETS_FILE=/secure/path/app-secrets.json
 
 # Encryption key for ODS connection strings stored in EdFi_Admin.OdsInstances
 # Generate with: openssl rand -base64 32
@@ -79,6 +82,9 @@ TRUST_PROXY=false
 MULTITENANCY_ENABLED=false
 
 # Tenant list: use TENANTS_CONNECTION_CONFIG JSON, or set TENANTS_CONFIG_MODULE for a plugin (see docs/tenants-config-plugin.md).
+# Example file-based plugin (reference only); TENANTS_CONFIG_FILE is read by this plugin, not core:
+# TENANTS_CONFIG_MODULE=./src/config/examples/tenants-config-file.js
+# TENANTS_CONFIG_FILE=/secure/path/tenants.json
 
 # Reload tenant list without restart when TENANTS_CONFIG_MODULE is set: kill -USR2 <pid> (Linux)
 

--- a/docs/app-secrets-plugin.md
+++ b/docs/app-secrets-plugin.md
@@ -38,4 +38,27 @@ If the plugin **omits** `pgBossConnectionConfig`, core does not set `PG_BOSS_CON
 
 ## `APP_SECRETS_MODULE` specifier
 
-Same rules as **`TENANTS_CONFIG_MODULE`** (see [Tenant configuration plugin](./tenants-config-plugin.md)): resolved relative to the process current working directory for `./` and `../`; absolute paths and `file:` URLs are supported; bare specifiers resolve as npm packages.
+Same rules as **`TENANTS_CONFIG_MODULE`** (see [Tenant configuration plugin](./tenants-config-plugin.md)): resolved relative to the process current working directory for `./`, `../`, `.\` or `..\`; absolute paths and `file:` URLs are supported; bare specifiers resolve as npm packages.
+
+## Example implementation
+
+[`src/config/examples/app-secrets-file.js`](../src/config/examples/app-secrets-file.js) is a minimal, dependency-free reference that reads the secrets from a JSON file. It exists to demonstrate the contract — a production plugin should fetch these from a secrets manager or vault rather than from a file on disk.
+
+Enable it with:
+
+```bash
+APP_SECRETS_MODULE=./src/config/examples/app-secrets-file.js
+APP_SECRETS_FILE=/secure/path/app-secrets.json
+```
+
+`APP_SECRETS_FILE` is specific to this example plugin (not read by core). The JSON file matches the `loadAppSecrets()` return shape:
+
+```json
+{
+  "odsConnectionStringEncryptionKey": "<base64 32-byte key>",
+  "oauth2PublicKeyPem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n",
+  "pgBossConnectionConfig": { "adminConnection": "host=...;database=...;username=...;password=..." }
+}
+```
+
+`pgBossConnectionConfig` is optional — include it (with `DB_TYPE=postgres`) to supply `PG_BOSS_CONNECTION_CONFIG` from the plugin; otherwise it must come from the environment.

--- a/docs/tenants-config-plugin.md
+++ b/docs/tenants-config-plugin.md
@@ -24,8 +24,33 @@ Plugin-specific environment variables belong in that module’s documentation, n
 
 ## `TENANTS_CONFIG_MODULE` specifier
 
-Resolved relative to the process current working directory when the path starts with `./` or `../`; absolute filesystem paths and `file:` URLs are supported; bare specifiers resolve as npm packages (e.g. `@scope/tenant-loader`).
+Resolved relative to the process current working directory when the path starts with `./`, `../`, `.\` or `..\`; absolute filesystem paths and `file:` URLs are supported; bare specifiers resolve as npm packages (e.g. `@scope/tenant-loader`).
+
+## Example implementation
+
+[`src/config/examples/tenants-config-file.js`](../src/config/examples/tenants-config-file.js) is a minimal, dependency-free reference that reads the tenant map from a JSON file. It exists to demonstrate the contract — a production plugin should fetch tenants and credentials from a secrets manager or directory service rather than from a file on disk.
+
+Enable it with:
+
+```bash
+MULTITENANCY_ENABLED=true
+TENANTS_CONFIG_MODULE=./src/config/examples/tenants-config-file.js
+TENANTS_CONFIG_FILE=/secure/path/tenants.json
+```
+
+`TENANTS_CONFIG_FILE` is specific to this example plugin (not read by core). The JSON file uses the same shape as `TENANTS_CONNECTION_CONFIG`:
+
+```json
+{
+  "Tenant1": { "adminConnection": "host=...;database=EdFi_Admin_Tenant1;username=...;password=..." },
+  "Tenant2": { "adminConnection": "host=...;database=EdFi_Admin_Tenant2;username=...;password=..." }
+}
+```
+
+Each value may also include an optional `OdsInstances` map (same shape as in `TENANTS_CONNECTION_CONFIG`) to resolve ODS connections directly. The file is re-read on every call, so combined with **SIGUSR2** (below) you can edit it and reload tenants without a restart.
 
 ## Reload without restart
 
 When **`TENANTS_CONFIG_MODULE`** is set, send **SIGUSR2** to the Node process to reload tenants via the same module (e.g. `kill -USR2 <pid>` on Linux).
+
+> **Windows:** Node.js does not support `SIGUSR2` on native Windows, so there is no in-place reload there — restart the process to pick up tenant changes. The signal-based reload works on Linux/macOS (including Linux containers), but not on IIS-based deployments on Windows.

--- a/src/config/examples/app-secrets-file.js
+++ b/src/config/examples/app-secrets-file.js
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to EdTech Consortium, Inc. under one or more agreements.
+// EdTech Consortium, Inc. licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+/**
+ * Example app-secrets plugin (reference/documentation only).
+ *
+ * Demonstrates the APP_SECRETS_MODULE contract (see docs/app-secrets-plugin.md) with no
+ * external dependency: it reads secrets from a JSON file whose path is given by the
+ * APP_SECRETS_FILE environment variable. A production plugin would instead fetch these
+ * from a secrets manager / vault rather than from a file on disk.
+ *
+ * Enable with:
+ *   APP_SECRETS_MODULE=./src/config/examples/app-secrets-file.js
+ *   APP_SECRETS_FILE=/secure/path/app-secrets.json
+ *
+ * The file is a JSON object matching the loadAppSecrets() return shape:
+ *   {
+ *     "odsConnectionStringEncryptionKey": "<base64 32-byte key>",
+ *     "oauth2PublicKeyPem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n",
+ *     "pgBossConnectionConfig": { "adminConnection": "host=...;database=...;..." }
+ *   }
+ * `pgBossConnectionConfig` is optional; include it (with DB_TYPE=postgres) to supply
+ * PG_BOSS_CONNECTION_CONFIG from the plugin. Core trims and assigns the returned values.
+ */
+
+import { readFile } from 'node:fs/promises';
+
+const ENV_VAR = 'APP_SECRETS_FILE';
+
+/**
+ * @returns {Promise<{
+ *   odsConnectionStringEncryptionKey: string,
+ *   oauth2PublicKeyPem: string,
+ *   pgBossConnectionConfig?: { adminConnection: string }
+ * }>}
+ */
+export async function loadAppSecrets() {
+  const filePath = (process.env[ENV_VAR] || '').trim();
+  if (!filePath) {
+    throw new Error(`${ENV_VAR} must be set for the example app secrets plugin`);
+  }
+
+  let raw;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(`Failed to read ${ENV_VAR} (${filePath}): ${error.message}`);
+  }
+
+  let secrets;
+  try {
+    secrets = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${ENV_VAR} (${filePath}) must contain valid JSON: ${error.message}`);
+  }
+
+  if (!secrets || typeof secrets !== 'object' || Array.isArray(secrets)) {
+    throw new Error(`${ENV_VAR} (${filePath}) must contain a JSON object`);
+  }
+
+  const { odsConnectionStringEncryptionKey, oauth2PublicKeyPem, pgBossConnectionConfig } = secrets;
+
+  if (typeof odsConnectionStringEncryptionKey !== 'string' || !odsConnectionStringEncryptionKey.trim()) {
+    throw new Error(`${ENV_VAR} (${filePath}) must include a non-empty string odsConnectionStringEncryptionKey`);
+  }
+  if (typeof oauth2PublicKeyPem !== 'string' || !oauth2PublicKeyPem.trim()) {
+    throw new Error(`${ENV_VAR} (${filePath}) must include a non-empty string oauth2PublicKeyPem`);
+  }
+
+  const result = { odsConnectionStringEncryptionKey, oauth2PublicKeyPem };
+
+  // pgBossConnectionConfig is optional; validate it only when present so callers get a
+  // file-aware error instead of a generic one from core.
+  if (pgBossConnectionConfig !== undefined && pgBossConnectionConfig !== null) {
+    const adminConnection = pgBossConnectionConfig?.adminConnection;
+    if (typeof adminConnection !== 'string' || !adminConnection.trim()) {
+      throw new Error(`${ENV_VAR} (${filePath}) pgBossConnectionConfig.adminConnection must be a non-empty string when pgBossConnectionConfig is present`);
+    }
+    result.pgBossConnectionConfig = { adminConnection };
+  }
+
+  // No success log here: core (bootstrapAppSecretsIfNeeded) already logs "[AppSecrets] Loaded via plugin".
+  return result;
+}

--- a/src/config/examples/tenants-config-file.js
+++ b/src/config/examples/tenants-config-file.js
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to EdTech Consortium, Inc. under one or more agreements.
+// EdTech Consortium, Inc. licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+/**
+ * Example tenant-configuration plugin (reference/documentation only).
+ *
+ * Demonstrates the TENANTS_CONFIG_MODULE contract (see docs/tenants-config-plugin.md)
+ * with no external dependency: it reads the tenant map from a JSON file whose path is
+ * given by the TENANTS_CONFIG_FILE environment variable. A production plugin would
+ * instead fetch tenant names and credentials from a secrets manager or directory
+ * service rather than from a file on disk.
+ *
+ * Enable with:
+ *   MULTITENANCY_ENABLED=true
+ *   TENANTS_CONFIG_MODULE=./src/config/examples/tenants-config-file.js
+ *   TENANTS_CONFIG_FILE=/secure/path/tenants.json
+ *
+ * The file uses the same shape as TENANTS_CONNECTION_CONFIG, e.g.:
+ *   {
+ *     "Tenant1": { "adminConnection": "host=...;database=EdFi_Admin_Tenant1;username=...;password=..." }
+ *   }
+ * Each value may also carry an optional `OdsInstances` map (same shape as
+ * TENANTS_CONNECTION_CONFIG) to resolve ODS connections directly instead of querying
+ * the tenant's EdFi_Admin database.
+ *
+ * The file is re-read on every call, so SIGUSR2 (`kill -USR2 <pid>`) reloads edits without a restart.
+ */
+
+import { readFile } from 'node:fs/promises';
+
+const ENV_VAR = 'TENANTS_CONFIG_FILE';
+
+/**
+ * @returns {Promise<Record<string, { adminConnection: string, OdsInstances?: object }>>}
+ */
+export async function loadTenantsConfig() {
+  const filePath = (process.env[ENV_VAR] || '').trim();
+  if (!filePath) {
+    throw new Error(`${ENV_VAR} must be set for the example tenant configuration plugin`);
+  }
+
+  let raw;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(`Failed to read ${ENV_VAR} (${filePath}): ${error.message}`);
+  }
+
+  let config;
+  try {
+    config = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${ENV_VAR} (${filePath}) must contain valid JSON: ${error.message}`);
+  }
+
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    throw new Error(`${ENV_VAR} (${filePath}) must contain a JSON object mapping tenant IDs to { adminConnection }`);
+  }
+
+  return config;
+}

--- a/tests/unit-tests/examples-app-secrets-file.test.js
+++ b/tests/unit-tests/examples-app-secrets-file.test.js
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to EdTech Consortium, Inc. under one or more agreements.
+// EdTech Consortium, Inc. licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { describe, test, expect, afterEach } from '@jest/globals';
+import { loadAppSecrets } from '../../src/config/examples/app-secrets-file.js';
+
+describe('example app-secrets-file plugin', () => {
+  let dir;
+
+  afterEach(async () => {
+    delete process.env.APP_SECRETS_FILE;
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  async function writeSecrets(contents) {
+    dir = await mkdtemp(path.join(os.tmpdir(), 'app-secrets-'));
+    const file = path.join(dir, 'app-secrets.json');
+    await writeFile(file, typeof contents === 'string' ? contents : JSON.stringify(contents), 'utf8');
+    return file;
+  }
+
+  const validSecrets = {
+    odsConnectionStringEncryptionKey: 'base64key==',
+    oauth2PublicKeyPem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----\n'
+  };
+
+  test('loads the required secrets from the JSON file', async () => {
+    process.env.APP_SECRETS_FILE = await writeSecrets(validSecrets);
+
+    const result = await loadAppSecrets();
+
+    expect(result.odsConnectionStringEncryptionKey).toBe('base64key==');
+    expect(result.oauth2PublicKeyPem).toContain('BEGIN PUBLIC KEY');
+    expect(result.pgBossConnectionConfig).toBeUndefined();
+  });
+
+  test('includes pgBossConnectionConfig when present', async () => {
+    process.env.APP_SECRETS_FILE = await writeSecrets({
+      ...validSecrets,
+      pgBossConnectionConfig: { adminConnection: 'host=db;database=pgboss;username=u;password=p' }
+    });
+
+    const result = await loadAppSecrets();
+
+    expect(result.pgBossConnectionConfig).toEqual({ adminConnection: 'host=db;database=pgboss;username=u;password=p' });
+  });
+
+  test('throws when APP_SECRETS_FILE is not set', async () => {
+    delete process.env.APP_SECRETS_FILE;
+    await expect(loadAppSecrets()).rejects.toThrow('APP_SECRETS_FILE must be set');
+  });
+
+  test('throws when the file does not exist', async () => {
+    process.env.APP_SECRETS_FILE = path.join(os.tmpdir(), 'app-secrets-does-not-exist-7b2e9d.json');
+    await expect(loadAppSecrets()).rejects.toThrow('Failed to read APP_SECRETS_FILE');
+  });
+
+  test('throws when the file is not valid JSON', async () => {
+    process.env.APP_SECRETS_FILE = await writeSecrets('{ not json');
+    await expect(loadAppSecrets()).rejects.toThrow('must contain valid JSON');
+  });
+
+  test('throws when the JSON is not an object', async () => {
+    process.env.APP_SECRETS_FILE = await writeSecrets('[]');
+    await expect(loadAppSecrets()).rejects.toThrow('must contain a JSON object');
+  });
+
+  test('throws when odsConnectionStringEncryptionKey is missing', async () => {
+    process.env.APP_SECRETS_FILE = await writeSecrets({ oauth2PublicKeyPem: 'pem' });
+    await expect(loadAppSecrets()).rejects.toThrow('odsConnectionStringEncryptionKey');
+  });
+
+  test('throws when oauth2PublicKeyPem is missing', async () => {
+    process.env.APP_SECRETS_FILE = await writeSecrets({ odsConnectionStringEncryptionKey: 'key' });
+    await expect(loadAppSecrets()).rejects.toThrow('oauth2PublicKeyPem');
+  });
+
+  test('throws when pgBossConnectionConfig is present but adminConnection is empty', async () => {
+    process.env.APP_SECRETS_FILE = await writeSecrets({
+      ...validSecrets,
+      pgBossConnectionConfig: { adminConnection: '   ' }
+    });
+    await expect(loadAppSecrets()).rejects.toThrow('pgBossConnectionConfig.adminConnection');
+  });
+});

--- a/tests/unit-tests/examples-tenants-config-file.test.js
+++ b/tests/unit-tests/examples-tenants-config-file.test.js
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to EdTech Consortium, Inc. under one or more agreements.
+// EdTech Consortium, Inc. licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { describe, test, expect, afterEach } from '@jest/globals';
+import { loadTenantsConfig } from '../../src/config/examples/tenants-config-file.js';
+
+describe('example tenants-config-file plugin', () => {
+  let dir;
+
+  afterEach(async () => {
+    delete process.env.TENANTS_CONFIG_FILE;
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  async function writeConfig(contents) {
+    dir = await mkdtemp(path.join(os.tmpdir(), 'tenants-cfg-'));
+    const file = path.join(dir, 'tenants.json');
+    await writeFile(file, contents, 'utf8');
+    return file;
+  }
+
+  test('loads the tenant map from the JSON file', async () => {
+    process.env.TENANTS_CONFIG_FILE = await writeConfig(
+      JSON.stringify({
+        Tenant1: { adminConnection: 'host=db;database=EdFi_Admin_Tenant1;username=u;password=p' },
+        Tenant2: { adminConnection: 'host=db;database=EdFi_Admin_Tenant2;username=u;password=p' }
+      })
+    );
+
+    const config = await loadTenantsConfig();
+
+    expect(Object.keys(config)).toEqual(['Tenant1', 'Tenant2']);
+    expect(config.Tenant1.adminConnection).toContain('database=EdFi_Admin_Tenant1');
+  });
+
+  test('throws when TENANTS_CONFIG_FILE is not set', async () => {
+    delete process.env.TENANTS_CONFIG_FILE;
+    await expect(loadTenantsConfig()).rejects.toThrow('TENANTS_CONFIG_FILE must be set');
+  });
+
+  test('throws when the file does not exist', async () => {
+    process.env.TENANTS_CONFIG_FILE = path.join(os.tmpdir(), 'tenants-does-not-exist-9f3c1a.json');
+    await expect(loadTenantsConfig()).rejects.toThrow('Failed to read TENANTS_CONFIG_FILE');
+  });
+
+  test('throws when the file is not valid JSON', async () => {
+    process.env.TENANTS_CONFIG_FILE = await writeConfig('{ not json');
+    await expect(loadTenantsConfig()).rejects.toThrow('must contain valid JSON');
+  });
+
+  test('throws when the JSON is not an object', async () => {
+    process.env.TENANTS_CONFIG_FILE = await writeConfig('[]');
+    await expect(loadTenantsConfig()).rejects.toThrow('must contain a JSON object');
+  });
+});


### PR DESCRIPTION
Add lightweight examples demonstrating the TENANTS_CONFIG_MODULE and APP_SECRETS_MODULE plugin contracts.
- src/config/examples/tenants-config-file.js: loadTenantsConfig() reads the
    tenant map from a JSON file given by TENANTS_CONFIG_FILE.
- src/config/examples/app-secrets-file.js: loadAppSecrets() reads the ODS
    encryption key, OAuth2 public PEM, and optional pgBossConnectionConfig from a
    JSON file given by APP_SECRETS_FILE.