### PR TITLE
[ONEROSTER-106] Fix cross-section period merging in classes refresh

### DIFF
--- a/docs/design/oneroster-view-mappings.md
+++ b/docs/design/oneroster-view-mappings.md
@@ -94,7 +94,7 @@ Nuance: `calendar_windows` uses `grouping sets` to compute both school-level and
 
 ### `classes` ← `sections`, `courseOfferings`, `schools`
 
-One row per Ed-Fi `section`. `sourcedId = md5(lower(localCourseCode)-schoolId-schoolYear-lower(sectionIdentifier)-lower(sessionName))`. Joins `courseoffering` on the full natural key for the title and course reference; left-joins `sectionclassperiod` aggregated into a `periods` JSON array. `classType` is hard-coded `'scheduled'`; `grades`, `subjects`, `subjectCodes` are `NULL` (not derivable). Emits references to its `course`, `school` (org), and `terms` (academic session).
+One row per Ed-Fi `section`. `sourcedId = md5(lower(localCourseCode)-schoolId-schoolYear-lower(sectionIdentifier)-lower(sessionName))`. Joins `courseoffering` on the full natural key for the title and course reference; left-joins `sectionclassperiod` aggregated into a `periods` JSON array, grouped/joined on the full Section natural key (`localCourseCode, schoolId, schoolYear, sectionIdentifier, sessionName`) — not `sectionIdentifier` alone, since that value is commonly reused across schools/districts in a shared ODS and would otherwise merge unrelated sections' periods together. `classType` is hard-coded `'scheduled'`; `grades`, `subjects`, `subjectCodes` are `NULL` (not derivable). Emits references to its `course`, `school` (org), and `terms` (academic session).
 
 ### `courses` ← `courses`, `courseOfferings`, `schools`
 

--- a/standard/4.0.0/artifacts/mssql/core/classes.sql
+++ b/standard/4.0.0/artifacts/mssql/core/classes.sql
@@ -138,13 +138,13 @@ BEGIN
         ),
         periods AS (
             SELECT
-                SectionIdentifier,
-                '[' + STRING_AGG('"' + ClassPeriodName + '"', ',') WITHIN GROUP (ORDER BY ClassPeriodName) + ']' AS periods
+                SectionIdentifier, LocalCourseCode, SchoolId, SchoolYear, SessionName,
+                '[' + STRING_AGG(CAST('"' + ClassPeriodName + '"' AS NVARCHAR(MAX)), ',') WITHIN GROUP (ORDER BY ClassPeriodName) + ']' AS periods
             FROM (
-                SELECT DISTINCT SectionIdentifier, ClassPeriodName
+                SELECT DISTINCT SectionIdentifier, LocalCourseCode, SchoolId, SchoolYear, SessionName, ClassPeriodName
                 FROM edfi.SectionClassPeriod
             ) distinct_periods
-            GROUP BY SectionIdentifier
+            GROUP BY SectionIdentifier, LocalCourseCode, SchoolId, SchoolYear, SessionName
         ),
         classes AS (
             SELECT
@@ -214,6 +214,10 @@ BEGIN
                 AND section.SchoolYear = courseoffering.SchoolYear
                 AND section.SessionName = courseoffering.SessionName
             LEFT JOIN periods ON section.SectionIdentifier = periods.SectionIdentifier
+                AND section.LocalCourseCode = periods.LocalCourseCode
+                AND section.SchoolId = periods.SchoolId
+                AND section.SchoolYear = periods.SchoolYear
+                AND section.SessionName = periods.SessionName
         )
         INSERT INTO #staging_classes
         SELECT

--- a/standard/4.0.0/artifacts/pgsql/core/classes.sql
+++ b/standard/4.0.0/artifacts/pgsql/core/classes.sql
@@ -21,10 +21,10 @@ courseoffering as (
 ),
 periods as (
     select
-        sectionidentifier,
+        sectionidentifier, localcoursecode, schoolid, schoolyear, sessionname,
         jsonb_agg(distinct classperiodname) as periods
     from edfi.sectionclassperiod
-    group by 1
+    group by sectionidentifier, localcoursecode, schoolid, schoolyear, sessionname
 ),
 -- property documentation at
 -- https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#Main6p6p2
@@ -102,6 +102,10 @@ classes as (
             AND section.sessionname = courseoffering.sessionname
 	    left join periods
             on section.sectionidentifier = periods.sectionidentifier
+            and section.localcoursecode = periods.localcoursecode
+            and section.schoolid = periods.schoolid
+            and section.schoolyear = periods.schoolyear
+            and section.sessionname = periods.sessionname
 )
 select * from classes;
 

--- a/standard/5.2.0/artifacts/mssql/core/classes.sql
+++ b/standard/5.2.0/artifacts/mssql/core/classes.sql
@@ -138,13 +138,13 @@ BEGIN
         ),
         periods AS (
             SELECT
-                SectionIdentifier,
-                '[' + STRING_AGG('"' + ClassPeriodName + '"', ',') WITHIN GROUP (ORDER BY ClassPeriodName) + ']' AS periods
+                SectionIdentifier, LocalCourseCode, SchoolId, SchoolYear, SessionName,
+                '[' + STRING_AGG(CAST('"' + ClassPeriodName + '"' AS NVARCHAR(MAX)), ',') WITHIN GROUP (ORDER BY ClassPeriodName) + ']' AS periods
             FROM (
-                SELECT DISTINCT SectionIdentifier, ClassPeriodName
+                SELECT DISTINCT SectionIdentifier, LocalCourseCode, SchoolId, SchoolYear, SessionName, ClassPeriodName
                 FROM edfi.SectionClassPeriod
             ) distinct_periods
-            GROUP BY SectionIdentifier
+            GROUP BY SectionIdentifier, LocalCourseCode, SchoolId, SchoolYear, SessionName
         ),
         classes AS (
             SELECT
@@ -215,6 +215,10 @@ BEGIN
                 AND section.SchoolYear = courseoffering.SchoolYear
                 AND section.SessionName = courseoffering.SessionName
             LEFT JOIN periods ON section.SectionIdentifier = periods.SectionIdentifier
+                AND section.LocalCourseCode = periods.LocalCourseCode
+                AND section.SchoolId = periods.SchoolId
+                AND section.SchoolYear = periods.SchoolYear
+                AND section.SessionName = periods.SessionName
         )
         INSERT INTO #staging_classes
         SELECT

--- a/standard/5.2.0/artifacts/pgsql/core/classes.sql
+++ b/standard/5.2.0/artifacts/pgsql/core/classes.sql
@@ -21,10 +21,10 @@ courseoffering as (
 ),
 periods as (
     select
-        sectionidentifier,
+        sectionidentifier, localcoursecode, schoolid, schoolyear, sessionname,
         jsonb_agg(distinct classperiodname) as periods
     from edfi.sectionclassperiod
-    group by 1
+    group by sectionidentifier, localcoursecode, schoolid, schoolyear, sessionname
 ),
 -- property documentation at
 -- https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#Main6p6p2
@@ -102,6 +102,10 @@ classes as (
             AND section.sessionname = courseoffering.sessionname
 	    left join periods
             on section.sectionidentifier = periods.sectionidentifier
+            and section.localcoursecode = periods.localcoursecode
+            and section.schoolid = periods.schoolid
+            and section.schoolyear = periods.schoolyear
+            and section.sessionname = periods.sessionname
 )
 select * from classes;
 


### PR DESCRIPTION
The periods CTE in oneroster12 classes grouped and joined SectionClassPeriod by SectionIdentifier alone, which is not unique in a statewide ODS. Sections from unrelated schools/sessions sharing the same SectionIdentifier had their ClassPeriodName values merged together, overflowing STRING_AGG's 8000-byte limit on SQL Server and silently producing wrong periods data on PostgreSQL. Group/join on the full Section natural key instead, and cast the STRING_AGG input to NVARCHAR(MAX) as a defensive measure against future large aggregates.