### PR TITLE
Support Npgsql style 'SSL Mode' when reading ODS connection strings.

### DIFF
--- a/src/config/postgres-ssl.js
+++ b/src/config/postgres-ssl.js
@@ -20,7 +20,8 @@ const readFile = (filePath, optionName) => {
 export const buildPostgresSslConfig = (connectionOptions) => {
   const sslConfig = {};
 
-  const sslMode = connectionOptions.sslmode?.toLowerCase();
+  // libpq: sslmode; Npgsql ("SSL Mode" after lowercasing): "ssl mode"
+  const sslMode = (connectionOptions.sslmode ?? connectionOptions['ssl mode'])?.toLowerCase();
 
   if (sslMode === 'disable') {
     return false;

--- a/tests/unit-tests/multi-tenancy-config.test.js
+++ b/tests/unit-tests/multi-tenancy-config.test.js
@@ -212,6 +212,22 @@ describe('multi-tenancy-config', () => {
         expect(result.ssl).toMatchObject({ rejectUnauthorized: true });
       });
 
+      test('sets rejectUnauthorized for Npgsql SSL Mode=Require', () => {
+        const result = parseConnectionString(
+          'host=localhost;database=db;username=u;password=p;SSL Mode=Require',
+          'postgres'
+        );
+        expect(result.ssl).toMatchObject({ rejectUnauthorized: true });
+      });
+
+      test('sets ssl to false for Npgsql SSL Mode=Disable', () => {
+        const result = parseConnectionString(
+          'host=localhost;database=db;username=u;password=p;SSL Mode=Disable',
+          'postgres'
+        );
+        expect(result.ssl).toBe(false);
+      });
+
       test('does not set ssl property when no sslmode is specified', () => {
         const result = parseConnectionString(
           'host=localhost;database=db;username=u;password=p',


### PR DESCRIPTION
Npgsql uses `SSL Mode` with a space.  This PR updates the postgres ssl config provider to recognize the option when parsing ODS connection strings from `dbo.odsinstances` in the admin database. 